### PR TITLE
Add fix for missing field on `@Expandable` properties.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 7.0.2 - 2020-04-30
+* [#77](https://github.com/vapor-community/stripe-kit/pull/77) Add fix for missing field on `@Expandable` properties.
+
 ## 7.0.1 - 2020-04-28
 * [#75](https://github.com/vapor-community/stripe-kit/pull/75) 
     * Made payout routes public.

--- a/Sources/StripeKit/Shared Models/StripeExpandable.swift
+++ b/Sources/StripeKit/Shared Models/StripeExpandable.swift
@@ -7,6 +7,12 @@
 
 import Foundation
 
+extension KeyedDecodingContainer {
+    func decode<T>(_ type: T.Type, forKey key: Self.Key) throws -> T where T : Decodable {
+        return try decodeIfPresent(type, forKey: key) ?? T(from: self.superDecoder())
+    }
+}
+
 @propertyWrapper
 public class Expandable<Model: StripeModel>: StripeModel {
     

--- a/Tests/StripeKitTests/ExpandableTests.swift
+++ b/Tests/StripeKitTests/ExpandableTests.swift
@@ -137,4 +137,195 @@ class ExpandableTests: XCTestCase {
         XCTAssertNotNil(appFee.$originatingTransaction(as: StripeCharge.self))
         XCTAssertNil(appFee.$originatingTransaction(as: StripeTransfer.self))
     }
+    
+    func testExpandable_decodesProperly_whenTopLevelField_isMissing() throws {
+        
+        let objectMissingExpandableTransferFieldOnCharge = """
+        {
+          "object": {
+            "id": "pi_1GdgW1IEV8X7ehfSpCasicNz",
+            "object": "payment_intent",
+            "amount": 2000,
+            "amount_capturable": 0,
+            "amount_received": 2000,
+            "application": null,
+            "application_fee_amount": null,
+            "canceled_at": null,
+            "cancellation_reason": null,
+            "capture_method": "automatic",
+            "charges": {
+              "object": "list",
+              "data": [
+                {
+                  "id": "ch_1GdgW2IEV8X7ehfSpaWh7SH4",
+                  "object": "charge",
+                  "amount": 2000,
+                  "amount_refunded": 0,
+                  "application": null,
+                  "application_fee": null,
+                  "application_fee_amount": null,
+                  "balance_transaction": "txn_1GdgW2IEV8X7ehfS6VWplXVL",
+                  "billing_details": {
+                    "address": {
+                      "city": null,
+                      "country": null,
+                      "line1": null,
+                      "line2": null,
+                      "postal_code": null,
+                      "state": null
+                    },
+                    "email": null,
+                    "name": null,
+                    "phone": null
+                  },
+                  "calculated_statement_descriptor": "CODANUT",
+                  "captured": true,
+                  "created": 1588268982,
+                  "currency": "usd",
+                  "customer": null,
+                  "description": "(created by Stripe CLI)",
+                  "destination": null,
+                  "dispute": null,
+                  "disputed": false,
+                  "failure_code": null,
+                  "failure_message": null,
+                  "fraud_details": {
+                  },
+                  "invoice": null,
+                  "livemode": false,
+                  "metadata": {
+                  },
+                  "on_behalf_of": null,
+                  "order": null,
+                  "outcome": {
+                    "network_status": "approved_by_network",
+                    "reason": null,
+                    "risk_level": "normal",
+                    "risk_score": 16,
+                    "seller_message": "Payment complete.",
+                    "type": "authorized"
+                  },
+                  "paid": true,
+                  "payment_intent": "pi_1GdgW1IEV8X7ehfSpCasicNz",
+                  "payment_method": "pm_1GdgW1IEV8X7ehfSHj6NWpKv",
+                  "payment_method_details": {
+                    "card": {
+                      "brand": "visa",
+                      "checks": {
+                        "address_line1_check": null,
+                        "address_postal_code_check": null,
+                        "cvc_check": null
+                      },
+                      "country": "US",
+                      "exp_month": 4,
+                      "exp_year": 2021,
+                      "fingerprint": "Kka7mYRiNKPJTIum",
+                      "funding": "credit",
+                      "installments": null,
+                      "last4": "4242",
+                      "network": "visa",
+                      "three_d_secure": null,
+                      "wallet": null
+                    },
+                    "type": "card"
+                  },
+                  "receipt_email": null,
+                  "receipt_number": null,
+                  "receipt_url": "https://pay.stripe.com/receipts/acct_1GQK3mIEV8X7ehfS/ch_1GdgW2IEV8X7ehfSpaWh7SH4/rcpt_HC4f61HVvgNeCToXazHDcOLU43dhs1u",
+                  "refunded": false,
+                  "refunds": {
+                    "object": "list",
+                    "data": [
+                    ],
+                    "has_more": false,
+                    "total_count": 0,
+                    "url": "/v1/charges/ch_1GdgW2IEV8X7ehfSpaWh7SH4/refunds"
+                  },
+                  "review": null,
+                  "shipping": {
+                    "address": {
+                      "city": "San Francisco",
+                      "country": "US",
+                      "line1": "510 Townsend St",
+                      "line2": null,
+                      "postal_code": "94103",
+                      "state": "CA"
+                    },
+                    "carrier": null,
+                    "name": "Jenny Rosen",
+                    "phone": null,
+                    "tracking_number": null
+                  },
+                  "source": null,
+                  "source_transfer": null,
+                  "statement_descriptor": null,
+                  "statement_descriptor_suffix": null,
+                  "status": "succeeded",
+                  "transfer_data": null,
+                  "transfer_group": null
+                }
+              ],
+              "has_more": false,
+              "total_count": 1,
+              "url": "/v1/charges?payment_intent=pi_1GdgW1IEV8X7ehfSpCasicNz"
+            },
+            "client_secret": "",
+            "confirmation_method": "automatic",
+            "created": 1588268981,
+            "currency": "usd",
+            "customer": null,
+            "description": "(created by Stripe CLI)",
+            "invoice": null,
+            "last_payment_error": null,
+            "livemode": false,
+            "metadata": {
+            },
+            "next_action": null,
+            "on_behalf_of": null,
+            "payment_method": "pm_1GdgW1IEV8X7ehfSHj6NWpKv",
+            "payment_method_options": {
+              "card": {
+                "installments": null,
+                "request_three_d_secure": "automatic"
+              }
+            },
+            "payment_method_types": [
+              "card"
+            ],
+            "receipt_email": null,
+            "review": null,
+            "setup_future_usage": null,
+            "shipping": {
+              "address": {
+                "city": "San Francisco",
+                "country": "US",
+                "line1": "510 Townsend St",
+                "line2": null,
+                "postal_code": "94103",
+                "state": "CA"
+              },
+              "carrier": null,
+              "name": "Jenny Rosen",
+              "phone": null,
+              "tracking_number": null
+            },
+            "source": null,
+            "statement_descriptor": null,
+            "statement_descriptor_suffix": null,
+            "status": "succeeded",
+            "transfer_data": null,
+            "transfer_group": null
+          }
+        }
+        """.data(using: .utf8)!
+        
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        do {
+           _ = try decoder.decode(StripeEventData.self, from: objectMissingExpandableTransferFieldOnCharge)
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
 }


### PR DESCRIPTION
This PR fixes a bug where a missing field/key in JSON would fail to decode an `@Expandable` property instead of just using `nil`.

- The fix is achieved by overriding the `decode` method and falling back if the key is missing.

- A test has been added to verify both `@Expandable` and `@DynamicExpandable` still work as expected. The test omits the `transfer` field on an `@Expandable` charge property eg `@Expandable<StripeTransfer> public var transfer: String?`

