### PR TITLE
Fix decoding for unitAmountDecimal

### DIFF
--- a/Sources/StripeKit/Billing/Credit Notes/CreditNoteLineItem.swift
+++ b/Sources/StripeKit/Billing/Credit Notes/CreditNoteLineItem.swift
@@ -34,7 +34,7 @@ public struct StripeCreditNoteLineItem: StripeModel {
     /// The cost of each unit of product being credited.
     public var unitAmount: Int?
     /// Same as `unit_amount`, but contains a decimal value with at most 12 decimal places.
-    public var unitAmountDecimal: Decimal?
+    public var unitAmountDecimal: String?
 }
 
 public enum StripeCreditNoteLineItemType: String, StripeModel {

--- a/Sources/StripeKit/Core Resources/Prices/Price.swift
+++ b/Sources/StripeKit/Core Resources/Prices/Price.swift
@@ -42,7 +42,73 @@ public struct StripePrice: StripeModel {
     /// Apply a transformation to the reported usage or set quantity before computing the amount billed. Cannot be combined with `tiers`.
     public var transformQuantity: StripePriceTransformQuantity?
     /// The unit amount in cents to be charged, represented as a decimal string with at most 12 decimal places.
-    public var unitAmountDecimal: String?
+    public var unitAmountDecimal: Decimal?
+    
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try values.decode(String.self, forKey: .id)
+        self.object = try values.decode(String.self, forKey: .object)
+        self.active = try values.decodeIfPresent(Bool.self, forKey: .active)
+        self.currency = try values.decodeIfPresent(StripeCurrency.self, forKey: .currency)
+        self.metadata = try values.decodeIfPresent([String: String].self, forKey: .metadata)
+        self._product = try values.decode(Expandable<StripeProduct>.self, forKey: .product)
+        self.recurring = try values.decodeIfPresent(StripePriceRecurring.self, forKey: .recurring)
+        self.type = try values.decodeIfPresent(StripePriceType.self, forKey: .type)
+        self.unitAmount = try values.decodeIfPresent(Int.self, forKey: .unitAmount)
+        self.billingScheme = try values.decodeIfPresent(StripePriceBillingScheme.self, forKey: .billingScheme)
+        self.created = try values.decode(Date.self, forKey: .created)
+        self.livemode = try values.decodeIfPresent(Bool.self, forKey: .livemode)
+        self.lookupKey = try values.decodeIfPresent(String.self, forKey: .lookupKey)
+        self.tiers = try values.decodeIfPresent([StripePriceTier].self, forKey: .tiers)
+        self.tiersMode = try values.decodeIfPresent(StripePriceTierMode.self, forKey: .tiersMode)
+        self.transformQuantity = try values.decodeIfPresent(StripePriceTransformQuantity.self, forKey: .transformQuantity)
+        let unitAmountDecimalString = try values.decodeIfPresent(String.self, forKey: .unitAmountDecimal)
+        self.unitAmountDecimal = Decimal(string: unitAmountDecimalString ?? "")
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(object, forKey: .object)
+        try container.encode(active, forKey: .active)
+        try container.encode(currency, forKey: .currency)
+        try container.encode(metadata, forKey: .metadata)
+        try container.encode(product, forKey: .product)
+        try container.encode(recurring, forKey: .recurring)
+        try container.encode(type, forKey: .type)
+        try container.encode(unitAmount, forKey: .unitAmount)
+        try container.encode(billingScheme, forKey: .billingScheme)
+        try container.encode(created, forKey: .created)
+        try container.encode(livemode, forKey: .livemode)
+        try container.encode(lookupKey, forKey: .lookupKey)
+        try container.encode(tiers, forKey: .tiers)
+        try container.encode(tiersMode, forKey: .tiersMode)
+        try container.encode(transformQuantity, forKey: .transformQuantity)
+        if let decimal = unitAmountDecimal {
+            let decimalString = "\(decimal)"
+            try container.encode(decimalString, forKey: .unitAmountDecimal)
+        }
+    }
+    
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case object
+        case active
+        case currency
+        case metadata
+        case product
+        case recurring
+        case type
+        case unitAmount
+        case billingScheme
+        case created
+        case livemode
+        case lookupKey
+        case tiers
+        case tiersMode
+        case transformQuantity
+        case unitAmountDecimal
+    }
 }
 
 public struct StripePriceRecurring: StripeModel {

--- a/Sources/StripeKit/Core Resources/Prices/Price.swift
+++ b/Sources/StripeKit/Core Resources/Prices/Price.swift
@@ -42,73 +42,7 @@ public struct StripePrice: StripeModel {
     /// Apply a transformation to the reported usage or set quantity before computing the amount billed. Cannot be combined with `tiers`.
     public var transformQuantity: StripePriceTransformQuantity?
     /// The unit amount in cents to be charged, represented as a decimal string with at most 12 decimal places.
-    public var unitAmountDecimal: Decimal?
-    
-    public init(from decoder: Decoder) throws {
-        let values = try decoder.container(keyedBy: CodingKeys.self)
-        self.id = try values.decode(String.self, forKey: .id)
-        self.object = try values.decode(String.self, forKey: .object)
-        self.active = try values.decodeIfPresent(Bool.self, forKey: .active)
-        self.currency = try values.decodeIfPresent(StripeCurrency.self, forKey: .currency)
-        self.metadata = try values.decodeIfPresent([String: String].self, forKey: .metadata)
-        self._product = try values.decode(Expandable<StripeProduct>.self, forKey: .product)
-        self.recurring = try values.decodeIfPresent(StripePriceRecurring.self, forKey: .recurring)
-        self.type = try values.decodeIfPresent(StripePriceType.self, forKey: .type)
-        self.unitAmount = try values.decodeIfPresent(Int.self, forKey: .unitAmount)
-        self.billingScheme = try values.decodeIfPresent(StripePriceBillingScheme.self, forKey: .billingScheme)
-        self.created = try values.decode(Date.self, forKey: .created)
-        self.livemode = try values.decodeIfPresent(Bool.self, forKey: .livemode)
-        self.lookupKey = try values.decodeIfPresent(String.self, forKey: .lookupKey)
-        self.tiers = try values.decodeIfPresent([StripePriceTier].self, forKey: .tiers)
-        self.tiersMode = try values.decodeIfPresent(StripePriceTierMode.self, forKey: .tiersMode)
-        self.transformQuantity = try values.decodeIfPresent(StripePriceTransformQuantity.self, forKey: .transformQuantity)
-        let unitAmountDecimalString = try values.decodeIfPresent(String.self, forKey: .unitAmountDecimal)
-        self.unitAmountDecimal = Decimal(string: unitAmountDecimalString ?? "")
-    }
-    
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(id, forKey: .id)
-        try container.encode(object, forKey: .object)
-        try container.encode(active, forKey: .active)
-        try container.encode(currency, forKey: .currency)
-        try container.encode(metadata, forKey: .metadata)
-        try container.encode(product, forKey: .product)
-        try container.encode(recurring, forKey: .recurring)
-        try container.encode(type, forKey: .type)
-        try container.encode(unitAmount, forKey: .unitAmount)
-        try container.encode(billingScheme, forKey: .billingScheme)
-        try container.encode(created, forKey: .created)
-        try container.encode(livemode, forKey: .livemode)
-        try container.encode(lookupKey, forKey: .lookupKey)
-        try container.encode(tiers, forKey: .tiers)
-        try container.encode(tiersMode, forKey: .tiersMode)
-        try container.encode(transformQuantity, forKey: .transformQuantity)
-        if let decimal = unitAmountDecimal {
-            let decimalString = "\(decimal)"
-            try container.encode(decimalString, forKey: .unitAmountDecimal)
-        }
-    }
-    
-    private enum CodingKeys: String, CodingKey {
-        case id
-        case object
-        case active
-        case currency
-        case metadata
-        case product
-        case recurring
-        case type
-        case unitAmount
-        case billingScheme
-        case created
-        case livemode
-        case lookupKey
-        case tiers
-        case tiersMode
-        case transformQuantity
-        case unitAmountDecimal
-    }
+    public var unitAmountDecimal: String?
 }
 
 public struct StripePriceRecurring: StripeModel {

--- a/Sources/StripeKit/Core Resources/Prices/Price.swift
+++ b/Sources/StripeKit/Core Resources/Prices/Price.swift
@@ -42,7 +42,7 @@ public struct StripePrice: StripeModel {
     /// Apply a transformation to the reported usage or set quantity before computing the amount billed. Cannot be combined with `tiers`.
     public var transformQuantity: StripePriceTransformQuantity?
     /// The unit amount in cents to be charged, represented as a decimal string with at most 12 decimal places.
-    public var unitAmountDecimal: Decimal?
+    public var unitAmountDecimal: String?
 }
 
 public struct StripePriceRecurring: StripeModel {

--- a/Sources/StripeKit/Core Resources/Prices/Price.swift
+++ b/Sources/StripeKit/Core Resources/Prices/Price.swift
@@ -77,11 +77,11 @@ public struct StripePriceTier: StripeModel {
     /// Price for the entire tier.
     public var flatAmount: Int?
     /// Same as `flat_amount`, but contains a decimal value with at most 12 decimal places.
-    public var flatAmountDecimal: Decimal?
+    public var flatAmountDecimal: String?
     /// Per unit price for units relevant to the tier.
     public var unitAmount: Int?
     /// Same as `unit_amount`, but contains a decimal value with at most 12 decimal places.
-    public var unitAmountDecimal: Decimal?
+    public var unitAmountDecimal: String?
     /// Up to and including to this quantity will be contained in the tier.
     public var upTo: Int?
 }

--- a/Sources/StripeKit/Payment Methods/Sources/SourceRoutes.swift
+++ b/Sources/StripeKit/Payment Methods/Sources/SourceRoutes.swift
@@ -104,19 +104,19 @@ extension SourceRoutes {
                        usage: StripeSourceUsage? = nil,
                        sources: [String: Any]? = nil) -> EventLoopFuture<StripeSource> {
         return create(type: type,
-                          amount: amount,
-                          currency: currency,
-                          flow: flow,
-                          mandate: mandate,
-                          metadata: metadata,
-                          owner: owner,
-                          receiver: receiver,
-                          redirect: redirect,
-                          sourceOrder: sourceOrder,
-                          statementDescriptor: statementDescriptor,
-                          token: token,
-                          usage: usage,
-                          sources: sources)
+                      amount: amount,
+                      currency: currency,
+                      flow: flow,
+                      mandate: mandate,
+                      metadata: metadata,
+                      owner: owner,
+                      receiver: receiver,
+                      redirect: redirect,
+                      sourceOrder: sourceOrder,
+                      statementDescriptor: statementDescriptor,
+                      token: token,
+                      usage: usage,
+                      sources: sources)
     }
     
     public func retrieve(source: String, clientSecret: String? = nil) -> EventLoopFuture<StripeSource> {


### PR DESCRIPTION
the `StripePrice` object wasn't decoded properly and crashed upon decoding. I now changed it to use custom decoding and encoding to first decode the value as a string and then convert that to a decimal value to store in the type. :) Unfortunately that needed the whole CodingKeys boilerplate etc in order to work..