### PR TITLE
ignore negative timeDifference

### DIFF
--- a/Sources/StripeKit/StripeClient+SignatureVerification.swift
+++ b/Sources/StripeKit/StripeClient+SignatureVerification.swift
@@ -54,7 +54,7 @@ extension StripeClient {
         
         let timeDifference = Date().timeIntervalSince(Date(timeIntervalSince1970: time))
         
-        if tolerance > 0 && timeDifference > tolerance || timeDifference < 0 {
+        if tolerance > 0 && timeDifference > tolerance {
             throw StripeSignatureError.timestampNotTolerated
         }
     }


### PR DESCRIPTION
as reflected in [official library](https://github.com/stripe/stripe-node/blob/e195e0723e721f65f822e802ae6e9b154fd2a0fe/lib/Webhooks.js#L131) ignore negative timeDifference as suggested by @madsodgaard