### PR TITLE
Implement Tracing

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "StripeKit", targets: ["StripeKit"])
     ],
     dependencies: [
-        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.1.0"),
+        .package(url: "https://github.com/slashmo/async-http-client.git", .branch("feature/tracing")),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0")
     ],
     targets: [

--- a/Sources/StripeKit/Billing/Coupons/CouponRoutes.swift
+++ b/Sources/StripeKit/Billing/Coupons/CouponRoutes.swift
@@ -9,6 +9,7 @@
 import NIO
 import NIOHTTP1
 import Foundation
+import Baggage
 
 public protocol CouponRoutes {
     /// You can create coupons easily via the [coupon management page](https://dashboard.stripe.com/coupons) of the Stripe dashboard. Coupon creation is also accessible via the API if you need to create coupons on the fly. /n A coupon has either a `percent_off` or an `amount_off` and `currency`. If you set an `amount_off`, that amount will be subtracted from any invoice’s subtotal. For example, an invoice with a subtotal of $100 will have a final total of $0 if a coupon with an `amount_off` of 20000 is applied to it and an invoice with a subtotal of $300 will have a final total of $100 if a coupon with an `amount_off` of 20000 is applied to it.
@@ -34,13 +35,14 @@ public protocol CouponRoutes {
                 metadata: [String: String]?,
                 name: String?,
                 percentOff: Int?,
-                redeemBy: Date?) -> EventLoopFuture<StripeCoupon>
+                redeemBy: Date?,
+                context: LoggingContext) -> EventLoopFuture<StripeCoupon>
     
     /// Retrieves the coupon with the given ID.
     ///
     /// - Parameter coupon: The ID of the desired coupon.
     /// - Returns: A `StripeCoupon`.
-    func retrieve(coupon: String) -> EventLoopFuture<StripeCoupon>
+    func retrieve(coupon: String, context: LoggingContext) -> EventLoopFuture<StripeCoupon>
     
     /// Updates the metadata of a coupon. Other coupon details (currency, duration, amount_off) are, by design, not editable.
     ///
@@ -49,19 +51,19 @@ public protocol CouponRoutes {
     ///   - metadata: A set of key-value pairs that you can attach to a coupon object. It can be useful for storing additional information about the coupon in a structured format.
     ///   - name: Name of the coupon displayed to customers on, for instance invoices, or receipts. By default the id is shown if name is not set.
     /// - Returns: A `StripeCoupon`.
-    func update(coupon: String, metadata: [String: String]?, name: String?) -> EventLoopFuture<StripeCoupon>
+    func update(coupon: String, metadata: [String: String]?, name: String?, context: LoggingContext) -> EventLoopFuture<StripeCoupon>
     
     /// You can delete coupons via the [coupon management page](https://dashboard.stripe.com/coupons) of the Stripe dashboard. However, deleting a coupon does not affect any customers who have already applied the coupon; it means that new customers can’t redeem the coupon. You can also delete coupons via the API.
     ///
     /// - Parameter coupon: The identifier of the coupon to be deleted.
     /// - Returns: A `StripeDeletedObject`.
-    func delete(coupon: String) -> EventLoopFuture<StripeDeletedObject>
+    func delete(coupon: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject>
     
     /// Returns a list of your coupons.
     ///
     /// - Parameter filter: A dictionary that will be used for the query parameters. [See More →](https://stripe.com/docs/api/coupons/list).
     /// - Returns: A `StripeCouponList`.
-    func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeCouponList>
+    func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeCouponList>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
@@ -77,7 +79,8 @@ extension CouponRoutes {
                        metadata: [String: String]? = nil,
                        name: String? = nil,
                        percentOff: Int? = nil,
-                       redeemBy: Date? = nil) -> EventLoopFuture<StripeCoupon> {
+                       redeemBy: Date? = nil,
+                       context: LoggingContext) -> EventLoopFuture<StripeCoupon> {
         return create(id: id,
                       duration: duration,
                       amountOff: amountOff,
@@ -90,19 +93,19 @@ extension CouponRoutes {
                       redeemBy: redeemBy)
     }
     
-    public func retrieve(coupon: String) -> EventLoopFuture<StripeCoupon> {
+    public func retrieve(coupon: String, context: LoggingContext) -> EventLoopFuture<StripeCoupon> {
         return retrieve(coupon: coupon)
     }
     
-    public func update(coupon: String, metadata: [String: String]? = nil, name: String? = nil) -> EventLoopFuture<StripeCoupon> {
+    public func update(coupon: String, metadata: [String: String]? = nil, name: String? = nil, context: LoggingContext) -> EventLoopFuture<StripeCoupon> {
         return update(coupon: coupon, metadata: metadata, name: name)
     }
     
-    public func delete(coupon: String) -> EventLoopFuture<StripeDeletedObject> {
+    public func delete(coupon: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
         return delete(coupon: coupon)
     }
     
-    public func listAll(filter: [String: Any]? = nil) -> EventLoopFuture<StripeCouponList> {
+    public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeCouponList> {
         return listAll(filter: filter)
     }
 }
@@ -126,7 +129,8 @@ public struct StripeCouponRoutes: CouponRoutes {
                        metadata: [String: String]?,
                        name: String?,
                        percentOff: Int?,
-                       redeemBy: Date?) -> EventLoopFuture<StripeCoupon> {
+                       redeemBy: Date?,
+                       context: LoggingContext) -> EventLoopFuture<StripeCoupon> {
         var body: [String: Any] = ["duration": duration.rawValue]
         
         if let id = id {
@@ -168,11 +172,11 @@ public struct StripeCouponRoutes: CouponRoutes {
         return apiHandler.send(method: .POST, path: coupons, body: .string(body.queryParameters), headers: headers)
     }
     
-    public func retrieve(coupon: String) -> EventLoopFuture<StripeCoupon> {
+    public func retrieve(coupon: String, context: LoggingContext) -> EventLoopFuture<StripeCoupon> {
         return apiHandler.send(method: .GET, path: "\(coupons)/\(coupon)", headers: headers)
     }
     
-    public func update(coupon: String, metadata: [String: String]?, name: String?) -> EventLoopFuture<StripeCoupon> {
+    public func update(coupon: String, metadata: [String: String]?, name: String?, context: LoggingContext) -> EventLoopFuture<StripeCoupon> {
         var body: [String: Any] = [:]
         
         if let metadata = metadata {
@@ -186,11 +190,11 @@ public struct StripeCouponRoutes: CouponRoutes {
         return apiHandler.send(method: .POST, path: "\(coupons)/\(coupon)", body: .string(body.queryParameters), headers: headers)
     }
     
-    public func delete(coupon: String) -> EventLoopFuture<StripeDeletedObject> {
+    public func delete(coupon: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
         return apiHandler.send(method: .DELETE, path: "\(coupons)/\(coupon)", headers: headers)
     }
     
-    public func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeCouponList> {
+    public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeCouponList> {
         var queryParams = ""
         if let filter = filter {
             queryParams = filter.queryParameters

--- a/Sources/StripeKit/Billing/Coupons/CouponRoutes.swift
+++ b/Sources/StripeKit/Billing/Coupons/CouponRoutes.swift
@@ -90,23 +90,24 @@ extension CouponRoutes {
                       metadata: metadata,
                       name: name,
                       percentOff: percentOff,
-                      redeemBy: redeemBy)
+                      redeemBy: redeemBy,
+                      context: context)
     }
     
     public func retrieve(coupon: String, context: LoggingContext) -> EventLoopFuture<StripeCoupon> {
-        return retrieve(coupon: coupon)
+        return retrieve(coupon: coupon, context: context)
     }
     
     public func update(coupon: String, metadata: [String: String]? = nil, name: String? = nil, context: LoggingContext) -> EventLoopFuture<StripeCoupon> {
-        return update(coupon: coupon, metadata: metadata, name: name)
+        return update(coupon: coupon, metadata: metadata, name: name, context: context)
     }
     
     public func delete(coupon: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
-        return delete(coupon: coupon)
+        return delete(coupon: coupon, context: context)
     }
     
     public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeCouponList> {
-        return listAll(filter: filter)
+        return listAll(filter: filter, context: context)
     }
 }
 
@@ -169,11 +170,11 @@ public struct StripeCouponRoutes: CouponRoutes {
             body["redeem_by"] = Int(redeemBy.timeIntervalSince1970)
         }
 
-        return apiHandler.send(method: .POST, path: coupons, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: coupons, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(coupon: String, context: LoggingContext) -> EventLoopFuture<StripeCoupon> {
-        return apiHandler.send(method: .GET, path: "\(coupons)/\(coupon)", headers: headers)
+        return apiHandler.send(method: .GET, path: "\(coupons)/\(coupon)", headers: headers, context: context)
     }
     
     public func update(coupon: String, metadata: [String: String]?, name: String?, context: LoggingContext) -> EventLoopFuture<StripeCoupon> {
@@ -187,11 +188,11 @@ public struct StripeCouponRoutes: CouponRoutes {
             body["name"] = name
         }
         
-        return apiHandler.send(method: .POST, path: "\(coupons)/\(coupon)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(coupons)/\(coupon)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func delete(coupon: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
-        return apiHandler.send(method: .DELETE, path: "\(coupons)/\(coupon)", headers: headers)
+        return apiHandler.send(method: .DELETE, path: "\(coupons)/\(coupon)", headers: headers, context: context)
     }
     
     public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeCouponList> {
@@ -200,6 +201,6 @@ public struct StripeCouponRoutes: CouponRoutes {
             queryParams = filter.queryParameters
         }
 
-        return apiHandler.send(method: .GET, path: coupons, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: coupons, query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Billing/Credit Notes/CreditNoteRoutes.swift
+++ b/Sources/StripeKit/Billing/Credit Notes/CreditNoteRoutes.swift
@@ -134,7 +134,8 @@ extension CreditNoteRoutes {
                       reason: reason,
                       refund: refund,
                       refundAmount: refundAmount,
-                      expand: expand)
+                      expand: expand,
+                      context: context)
     }
     
     public func preview(invoice: String,
@@ -159,11 +160,12 @@ extension CreditNoteRoutes {
                        reason: reason,
                        refund: refund,
                        refundAmount: refundAmount,
-                       expand: expand)
+                       expand: expand,
+                       context: context)
     }
     
     public func retrieve(id: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeCreditNote> {
-        return retrieve(id: id, expand: expand)
+        return retrieve(id: id, expand: expand, context: context)
     }
     
     public func update(id: String,
@@ -171,23 +173,23 @@ extension CreditNoteRoutes {
                        metadata: [String: String]? = nil,
                        expand: [String]? = nil,
                        context: LoggingContext) -> EventLoopFuture<StripeCreditNote> {
-        return update(id: id, memo: memo, metadata: metadata, expand: expand)
+        return update(id: id, memo: memo, metadata: metadata, expand: expand, context: context)
     }
     
     public func retrieveLineItems(id: String, filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeCreditNoteLineItemList> {
-        retrieveLineItems(id: id, filter: filter)
+        retrieveLineItems(id: id, filter: filter, context: context)
     }
     
     public func retrievePreviewLineItems(invoice: String, filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeCreditNoteLineItemList> {
-        retrievePreviewLineItems(invoice: invoice, filter: filter)
+        retrievePreviewLineItems(invoice: invoice, filter: filter, context: context)
     }
     
     public func void(id: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeCreditNote> {
-        return void(id: id, expand: expand)
+        return void(id: id, expand: expand, context: context)
     }
     
     public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeCreditNoteList> {
-        return listAll(filter: filter)
+        return listAll(filter: filter, context: context)
     }
 }
 
@@ -252,7 +254,7 @@ public struct StripeCreditNoteRoutes: CreditNoteRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: creditnotes, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: creditnotes, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func preview(invoice: String,
@@ -309,7 +311,7 @@ public struct StripeCreditNoteRoutes: CreditNoteRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(creditnotes)/preview", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(creditnotes)/preview", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(id: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeCreditNote> {
@@ -317,7 +319,7 @@ public struct StripeCreditNoteRoutes: CreditNoteRoutes {
         if let expand = expand {
             queryParams += ["expand": expand].queryParameters
         }
-        return apiHandler.send(method: .GET, path: "\(creditnotes)/\(id)", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(creditnotes)/\(id)", query: queryParams, headers: headers, context: context)
     }
     
     public func update(id: String,
@@ -339,7 +341,7 @@ public struct StripeCreditNoteRoutes: CreditNoteRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(creditnotes)/\(id)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(creditnotes)/\(id)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieveLineItems(id: String, filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeCreditNoteLineItemList> {
@@ -348,7 +350,7 @@ public struct StripeCreditNoteRoutes: CreditNoteRoutes {
             queryParams += filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: "\(creditnotes)/\(id)/lines", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(creditnotes)/\(id)/lines", query: queryParams, headers: headers, context: context)
     }
     
     public func retrievePreviewLineItems(invoice: String, filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeCreditNoteLineItemList> {
@@ -357,7 +359,7 @@ public struct StripeCreditNoteRoutes: CreditNoteRoutes {
             queryParams += "&" + filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: "\(creditnotes)/preview/lines", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(creditnotes)/preview/lines", query: queryParams, headers: headers, context: context)
     }
     
     public func void(id: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeCreditNote> {
@@ -367,7 +369,7 @@ public struct StripeCreditNoteRoutes: CreditNoteRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(creditnotes)/\(id)/void", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(creditnotes)/\(id)/void", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeCreditNoteList> {
@@ -376,7 +378,7 @@ public struct StripeCreditNoteRoutes: CreditNoteRoutes {
             queryParams += filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: creditnotes, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: creditnotes, query: queryParams, headers: headers, context: context)
     }
 }
 

--- a/Sources/StripeKit/Billing/Customer Balance Transactions/CustomerBalanceTransactionRoutes.swift
+++ b/Sources/StripeKit/Billing/Customer Balance Transactions/CustomerBalanceTransactionRoutes.swift
@@ -67,11 +67,11 @@ extension CustomerBalanceTransactionRoutes {
                       customer: customer,
                       description: description,
                       metadata: metadata,
-                      expand: expand)
+                      expand: expand, context: context)
     }
     
     public func retrieve(customer: String, transaction: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeCustomerBalanceTransaction> {
-        return retrieve(customer: customer, transaction: transaction, expand: expand)
+        return retrieve(customer: customer, transaction: transaction, expand: expand, context: context)
     }
     
     public func update(customer: String,
@@ -84,11 +84,12 @@ extension CustomerBalanceTransactionRoutes {
                       transaction: transaction,
                       description: description,
                       metadata: metadata,
-                      expand: expand)
+                      expand: expand,
+                      context: context)
     }
     
     public func listAll(customer: String, filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeCustomerBalanceTransactionList> {
-        return listAll(customer: customer, filter: filter)
+        return listAll(customer: customer, filter: filter, context: context)
     }
 }
 
@@ -124,7 +125,7 @@ public struct StripeCustomerBalanceTransactionRoutes: CustomerBalanceTransaction
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(customerbalancetransactions)/\(customer)/balance_transactions", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(customerbalancetransactions)/\(customer)/balance_transactions", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(customer: String, transaction: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeCustomerBalanceTransaction> {
@@ -132,7 +133,7 @@ public struct StripeCustomerBalanceTransactionRoutes: CustomerBalanceTransaction
         if let expand = expand {
             queryParams += ["expand": expand].queryParameters
         }
-        return apiHandler.send(method: .GET, path: "\(customerbalancetransactions)/\(customer)/balance_transactions/\(transaction)", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(customerbalancetransactions)/\(customer)/balance_transactions/\(transaction)", query: queryParams, headers: headers, context: context)
     }
     
     public func update(customer: String,
@@ -155,7 +156,7 @@ public struct StripeCustomerBalanceTransactionRoutes: CustomerBalanceTransaction
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(customerbalancetransactions)/\(customer)/balance_transactions/\(transaction)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(customerbalancetransactions)/\(customer)/balance_transactions/\(transaction)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func listAll(customer: String, filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeCustomerBalanceTransactionList> {
@@ -164,6 +165,6 @@ public struct StripeCustomerBalanceTransactionRoutes: CustomerBalanceTransaction
             queryParams += filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: "\(customerbalancetransactions)/\(customer)/balance_transactions", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(customerbalancetransactions)/\(customer)/balance_transactions", query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Billing/Customer Balance Transactions/CustomerBalanceTransactionRoutes.swift
+++ b/Sources/StripeKit/Billing/Customer Balance Transactions/CustomerBalanceTransactionRoutes.swift
@@ -7,6 +7,7 @@
 
 import NIO
 import NIOHTTP1
+import Baggage
 
 public protocol CustomerBalanceTransactionRoutes {
     
@@ -22,13 +23,14 @@ public protocol CustomerBalanceTransactionRoutes {
                 customer: String,
                 description: String?,
                 metadata: [String: String]?,
-                expand: [String]?) -> EventLoopFuture<StripeCustomerBalanceTransaction>
+                expand: [String]?,
+                context: LoggingContext) -> EventLoopFuture<StripeCustomerBalanceTransaction>
     
     /// Retrieves a specific transaction that updated the customer’s balance.
     /// - Parameter customer: The customer the transaction belongs to.
     /// - Parameter transaction: The transaction to retrieve.
     /// - Parameter expand: An array of properties to expand.
-    func retrieve(customer: String, transaction: String, expand: [String]?) -> EventLoopFuture<StripeCustomerBalanceTransaction>
+    func retrieve(customer: String, transaction: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeCustomerBalanceTransaction>
     
     /// Most customer balance transaction fields are immutable, but you may update its `description` and `metadata`.
     /// - Parameter customer: The customer the transaction belongs to.
@@ -40,12 +42,13 @@ public protocol CustomerBalanceTransactionRoutes {
                 transaction: String,
                 description: String?,
                 metadata: [String: String]?,
-                expand: [String]?) -> EventLoopFuture<StripeCustomerBalanceTransaction>
+                expand: [String]?,
+                context: LoggingContext) -> EventLoopFuture<StripeCustomerBalanceTransaction>
     
     /// Returns a list of transactions that updated the customer’s balance.
     /// - Parameter customer: The customer to retrieve transactions for.
     /// - Parameter filter: A dictionary that will be used for the query parameters. [See More →](https://stripe.com/docs/api/customer_balance_transactions/list)
-    func listAll(customer: String, filter: [String: Any]?) -> EventLoopFuture<StripeCustomerBalanceTransactionList>
+    func listAll(customer: String, filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeCustomerBalanceTransactionList>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
@@ -57,7 +60,8 @@ extension CustomerBalanceTransactionRoutes {
                        customer: String,
                        description: String? = nil,
                        metadata: [String: String]? = nil,
-                       expand: [String]? = nil) -> EventLoopFuture<StripeCustomerBalanceTransaction> {
+                       expand: [String]? = nil,
+                       context: LoggingContext) -> EventLoopFuture<StripeCustomerBalanceTransaction> {
         return create(amount: amount,
                       currency: currency,
                       customer: customer,
@@ -66,7 +70,7 @@ extension CustomerBalanceTransactionRoutes {
                       expand: expand)
     }
     
-    public func retrieve(customer: String, transaction: String, expand: [String]? = nil) -> EventLoopFuture<StripeCustomerBalanceTransaction> {
+    public func retrieve(customer: String, transaction: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeCustomerBalanceTransaction> {
         return retrieve(customer: customer, transaction: transaction, expand: expand)
     }
     
@@ -74,7 +78,8 @@ extension CustomerBalanceTransactionRoutes {
                        transaction: String,
                        description: String? = nil,
                        metadata: [String: String]? = nil,
-                       expand: [String]? = nil) -> EventLoopFuture<StripeCustomerBalanceTransaction> {
+                       expand: [String]? = nil,
+                       context: LoggingContext) -> EventLoopFuture<StripeCustomerBalanceTransaction> {
         return update(customer: customer,
                       transaction: transaction,
                       description: description,
@@ -82,7 +87,7 @@ extension CustomerBalanceTransactionRoutes {
                       expand: expand)
     }
     
-    public func listAll(customer: String, filter: [String: Any]? = nil) -> EventLoopFuture<StripeCustomerBalanceTransactionList> {
+    public func listAll(customer: String, filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeCustomerBalanceTransactionList> {
         return listAll(customer: customer, filter: filter)
     }
 }
@@ -102,7 +107,8 @@ public struct StripeCustomerBalanceTransactionRoutes: CustomerBalanceTransaction
                        customer: String,
                        description: String?,
                        metadata: [String: String]?,
-                       expand: [String]?) -> EventLoopFuture<StripeCustomerBalanceTransaction> {
+                       expand: [String]?,
+                       context: LoggingContext) -> EventLoopFuture<StripeCustomerBalanceTransaction> {
         var body: [String: Any] = ["amount": amount,
                                    "currency": currency.rawValue]
         
@@ -121,7 +127,7 @@ public struct StripeCustomerBalanceTransactionRoutes: CustomerBalanceTransaction
         return apiHandler.send(method: .POST, path: "\(customerbalancetransactions)/\(customer)/balance_transactions", body: .string(body.queryParameters), headers: headers)
     }
     
-    public func retrieve(customer: String, transaction: String, expand: [String]?) -> EventLoopFuture<StripeCustomerBalanceTransaction> {
+    public func retrieve(customer: String, transaction: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeCustomerBalanceTransaction> {
         var queryParams = ""
         if let expand = expand {
             queryParams += ["expand": expand].queryParameters
@@ -133,7 +139,8 @@ public struct StripeCustomerBalanceTransactionRoutes: CustomerBalanceTransaction
                        transaction: String,
                        description: String?,
                        metadata: [String: String]?,
-                       expand: [String]?) -> EventLoopFuture<StripeCustomerBalanceTransaction> {
+                       expand: [String]?,
+                       context: LoggingContext) -> EventLoopFuture<StripeCustomerBalanceTransaction> {
         var body: [String: Any] = [:]
         
         if let description = description {
@@ -151,7 +158,7 @@ public struct StripeCustomerBalanceTransactionRoutes: CustomerBalanceTransaction
         return apiHandler.send(method: .POST, path: "\(customerbalancetransactions)/\(customer)/balance_transactions/\(transaction)", body: .string(body.queryParameters), headers: headers)
     }
     
-    public func listAll(customer: String, filter: [String: Any]?) -> EventLoopFuture<StripeCustomerBalanceTransactionList> {
+    public func listAll(customer: String, filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeCustomerBalanceTransactionList> {
         var queryParams = ""
         if let filter = filter {
             queryParams += filter.queryParameters

--- a/Sources/StripeKit/Billing/Customer Portal/PortalConfigurationRoutes.swift
+++ b/Sources/StripeKit/Billing/Customer Portal/PortalConfigurationRoutes.swift
@@ -55,7 +55,8 @@ extension PortalConfigurationRoutes {
                        context: LoggingContext) -> EventLoopFuture<StripePortalConfiguration> {
         create(businessProfile: businessProfile,
                features: features,
-               defaultReturnUrl: defaultReturnUrl)
+               defaultReturnUrl: defaultReturnUrl,
+               context: context)
     }
     
     public func update(configuration: String,
@@ -68,15 +69,16 @@ extension PortalConfigurationRoutes {
                active: active,
                businessProfile: businessProfile,
                defaultReturnUrl: defaultReturnUrl,
-               features: features)
+               features: features,
+               context: context)
     }
     
     public func retrieve(configuration: String, context: LoggingContext) -> EventLoopFuture<StripePortalConfiguration> {
-        retrieve(configuration: configuration)
+        retrieve(configuration: configuration, context: context)
     }
     
     public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripePortalConfigurationList> {
-        listAll(filter: filter)
+        listAll(filter: filter, context: context)
     }
 }
 
@@ -104,7 +106,7 @@ public struct StripePortalConfigurationRoutes: PortalConfigurationRoutes {
             body["default_return_url"] = defaultReturnUrl
         }
         
-        return apiHandler.send(method: .POST, path: portalconfiguration, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: portalconfiguration, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func update(configuration: String,
@@ -131,11 +133,11 @@ public struct StripePortalConfigurationRoutes: PortalConfigurationRoutes {
             body["default_return_url"] = defaultReturnUrl
         }
         
-        return apiHandler.send(method: .POST, path: "\(portalconfiguration)/\(configuration)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(portalconfiguration)/\(configuration)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(configuration: String, context: LoggingContext) -> EventLoopFuture<StripePortalConfiguration> {
-        return apiHandler.send(method: .GET, path: "\(portalconfiguration)/\(configuration)", headers: headers)
+        return apiHandler.send(method: .GET, path: "\(portalconfiguration)/\(configuration)", headers: headers, context: context)
     }
     
     public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripePortalConfigurationList> {
@@ -144,6 +146,6 @@ public struct StripePortalConfigurationRoutes: PortalConfigurationRoutes {
             queryParams = filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: portalconfiguration, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: portalconfiguration, query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Billing/Customer Portal/PortalConfigurationRoutes.swift
+++ b/Sources/StripeKit/Billing/Customer Portal/PortalConfigurationRoutes.swift
@@ -7,6 +7,7 @@
 
 import NIO
 import NIOHTTP1
+import Baggage
 
 public protocol PortalConfigurationRoutes {
     /// Creates a configuration that describes the functionality and behavior of a PortalSession
@@ -16,7 +17,8 @@ public protocol PortalConfigurationRoutes {
     ///   - defaultReturnUrl: The default URL to redirect customers to when they click on the portal’s link to return to your website. This can be overriden when creating the session.
     func create(businessProfile: [String: Any],
                 features: [String: Any],
-                defaultReturnUrl: String?) -> EventLoopFuture<StripePortalConfiguration>
+                defaultReturnUrl: String?,
+                context: LoggingContext) -> EventLoopFuture<StripePortalConfiguration>
     
     /// Updates a configuration that describes the functionality of the customer portal.
     /// - Parameters:
@@ -29,17 +31,18 @@ public protocol PortalConfigurationRoutes {
                 active: Bool?,
                 businessProfile: [String: Any]?,
                 defaultReturnUrl: String?,
-                features: [String: Any]?) -> EventLoopFuture<StripePortalConfiguration>
+                features: [String: Any]?,
+                context: LoggingContext) -> EventLoopFuture<StripePortalConfiguration>
     
     /// Retrieves a configuration that describes the functionality of the customer portal.
     /// - Parameter configuration: The identifier of the configuration to retrieve.
-    func retrieve(configuration: String) -> EventLoopFuture<StripePortalConfiguration>
+    func retrieve(configuration: String, context: LoggingContext) -> EventLoopFuture<StripePortalConfiguration>
     
     /// Returns a list of tax IDs for a customer.
     ///
     /// - Parameter filter: A dictionary that will be used for the query parameters.
     /// - Returns: A `StripePortalConfigurationList`.
-    func listAll(filter: [String: Any]?) -> EventLoopFuture<StripePortalConfigurationList>
+    func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripePortalConfigurationList>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
@@ -48,7 +51,8 @@ public protocol PortalConfigurationRoutes {
 extension PortalConfigurationRoutes {
     public func create(businessProfile: [String: Any],
                        features: [String: Any],
-                       defaultReturnUrl: String? = nil) -> EventLoopFuture<StripePortalConfiguration> {
+                       defaultReturnUrl: String? = nil,
+                       context: LoggingContext) -> EventLoopFuture<StripePortalConfiguration> {
         create(businessProfile: businessProfile,
                features: features,
                defaultReturnUrl: defaultReturnUrl)
@@ -58,7 +62,8 @@ extension PortalConfigurationRoutes {
                        active: Bool? = nil,
                        businessProfile: [String: Any]? = nil,
                        defaultReturnUrl: String? = nil,
-                       features: [String: Any]? = nil) -> EventLoopFuture<StripePortalConfiguration> {
+                       features: [String: Any]? = nil,
+                       context: LoggingContext) -> EventLoopFuture<StripePortalConfiguration> {
         update(configuration: configuration,
                active: active,
                businessProfile: businessProfile,
@@ -66,11 +71,11 @@ extension PortalConfigurationRoutes {
                features: features)
     }
     
-    public func retrieve(configuration: String) -> EventLoopFuture<StripePortalConfiguration> {
+    public func retrieve(configuration: String, context: LoggingContext) -> EventLoopFuture<StripePortalConfiguration> {
         retrieve(configuration: configuration)
     }
     
-    public func listAll(filter: [String: Any]? = nil) -> EventLoopFuture<StripePortalConfigurationList> {
+    public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripePortalConfigurationList> {
         listAll(filter: filter)
     }
 }
@@ -87,7 +92,8 @@ public struct StripePortalConfigurationRoutes: PortalConfigurationRoutes {
     
     public func create(businessProfile: [String: Any],
                        features: [String: Any],
-                       defaultReturnUrl: String?) -> EventLoopFuture<StripePortalConfiguration> {
+                       defaultReturnUrl: String?,
+                       context: LoggingContext) -> EventLoopFuture<StripePortalConfiguration> {
         var body: [String: Any] = [:]
         
         businessProfile.forEach { body["business_profile[\($0)]"] = $1 }
@@ -105,7 +111,8 @@ public struct StripePortalConfigurationRoutes: PortalConfigurationRoutes {
                        active: Bool?,
                        businessProfile: [String: Any]?,
                        defaultReturnUrl: String?,
-                       features: [String: Any]?) -> EventLoopFuture<StripePortalConfiguration> {
+                       features: [String: Any]?,
+                       context: LoggingContext) -> EventLoopFuture<StripePortalConfiguration> {
         var body: [String: Any] = [:]
         
         if let active = active {
@@ -127,11 +134,11 @@ public struct StripePortalConfigurationRoutes: PortalConfigurationRoutes {
         return apiHandler.send(method: .POST, path: "\(portalconfiguration)/\(configuration)", body: .string(body.queryParameters), headers: headers)
     }
     
-    public func retrieve(configuration: String) -> EventLoopFuture<StripePortalConfiguration> {
+    public func retrieve(configuration: String, context: LoggingContext) -> EventLoopFuture<StripePortalConfiguration> {
         return apiHandler.send(method: .GET, path: "\(portalconfiguration)/\(configuration)", headers: headers)
     }
     
-    public func listAll(filter: [String: Any]?) -> EventLoopFuture<StripePortalConfigurationList> {
+    public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripePortalConfigurationList> {
         var queryParams = ""
         if let filter = filter {
             queryParams = filter.queryParameters

--- a/Sources/StripeKit/Billing/Customer Portal/PortalSessionRoutes.swift
+++ b/Sources/StripeKit/Billing/Customer Portal/PortalSessionRoutes.swift
@@ -7,6 +7,7 @@
 
 import NIO
 import NIOHTTP1
+import Baggage
 
 public protocol PortalSessionRoutes {
     /// Creates a session of the customer portal.
@@ -20,7 +21,8 @@ public protocol PortalSessionRoutes {
                 returnUrl: String?,
                 configuration: [String: Any]?,
                 onBehalfOf: String?,
-                expand: [String]?) -> EventLoopFuture<StripePortalSession>
+                expand: [String]?,
+                context: LoggingContext) -> EventLoopFuture<StripePortalSession>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
@@ -31,7 +33,8 @@ extension PortalSessionRoutes {
                        returnUrl: String? = nil,
                        configuration: [String: Any]? = nil,
                        onBehalfOf: String? = nil,
-                       expand: [String]? = nil) -> EventLoopFuture<StripePortalSession> {
+                       expand: [String]? = nil,
+                       context: LoggingContext) -> EventLoopFuture<StripePortalSession> {
         create(customer: customer,
                returnUrl: returnUrl,
                configuration: configuration,
@@ -54,7 +57,8 @@ public struct StripePortalSessionRoutes: PortalSessionRoutes {
                        returnUrl: String?,
                        configuration: [String: Any]?,
                        onBehalfOf: String?,
-                       expand: [String]?) -> EventLoopFuture<StripePortalSession> {
+                       expand: [String]?,
+                       context: LoggingContext) -> EventLoopFuture<StripePortalSession> {
         var body: [String: Any] = ["customer": customer]
         
         if let returnUrl = returnUrl {

--- a/Sources/StripeKit/Billing/Customer Portal/PortalSessionRoutes.swift
+++ b/Sources/StripeKit/Billing/Customer Portal/PortalSessionRoutes.swift
@@ -39,7 +39,8 @@ extension PortalSessionRoutes {
                returnUrl: returnUrl,
                configuration: configuration,
                onBehalfOf: onBehalfOf,
-               expand: expand)
+               expand: expand,
+               context: context)
     }
 }
 
@@ -77,6 +78,6 @@ public struct StripePortalSessionRoutes: PortalSessionRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: sessions, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: sessions, body: .string(body.queryParameters), headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Billing/Customer Tax IDs/CustomerTaxIDRoutes.swift
+++ b/Sources/StripeKit/Billing/Customer Tax IDs/CustomerTaxIDRoutes.swift
@@ -71,7 +71,7 @@ public struct StripeCustomerTaxIDRoutes: CustomerTaxIDRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(taxids)/\(customer)/tax_ids", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(taxids)/\(customer)/tax_ids", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(id: String, customer: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeTaxID> {
@@ -79,11 +79,11 @@ public struct StripeCustomerTaxIDRoutes: CustomerTaxIDRoutes {
         if let expand = expand {
             queryParams = ["expand": expand].queryParameters
         }
-        return apiHandler.send(method: .GET, path: "\(taxids)/\(customer)/tax_ids/\(id)", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(taxids)/\(customer)/tax_ids/\(id)", query: queryParams, headers: headers, context: context)
     }
     
     public func delete(id: String, customer: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
-        return apiHandler.send(method: .DELETE, path: "\(taxids)/\(customer)/tax_ids/\(id)", headers: headers)
+        return apiHandler.send(method: .DELETE, path: "\(taxids)/\(customer)/tax_ids/\(id)", headers: headers, context: context)
     }
     
     public func listAll(customer: String, filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeTaxIDList> {
@@ -92,6 +92,6 @@ public struct StripeCustomerTaxIDRoutes: CustomerTaxIDRoutes {
             queryParams = filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: "\(taxids)/\(customer)/tax_ids", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(taxids)/\(customer)/tax_ids", query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Billing/Customer Tax IDs/CustomerTaxIDRoutes.swift
+++ b/Sources/StripeKit/Billing/Customer Tax IDs/CustomerTaxIDRoutes.swift
@@ -7,6 +7,7 @@
 
 import NIO
 import NIOHTTP1
+import Baggage
 
 public protocol CustomerTaxIDRoutes {
     /// Creates a new `TaxID` object for a customer.
@@ -20,7 +21,8 @@ public protocol CustomerTaxIDRoutes {
     func create(customer: String,
                 type: StripeTaxIDType,
                 value: String,
-                expand: [String]?) -> EventLoopFuture<StripeTaxID>
+                expand: [String]?,
+                context: LoggingContext) -> EventLoopFuture<StripeTaxID>
     
     /// Retrieves the TaxID object with the given identifier.
     ///
@@ -29,7 +31,7 @@ public protocol CustomerTaxIDRoutes {
     ///   - customer: ID of the customer.
     ///   - expand: An array of properties to expand.
     /// - Returns: A `StripeTaxID`.
-    func retrieve(id: String, customer: String, expand: [String]?) -> EventLoopFuture<StripeTaxID>
+    func retrieve(id: String, customer: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeTaxID>
     
     /// Deletes an existing TaxID object.
     ///
@@ -37,7 +39,7 @@ public protocol CustomerTaxIDRoutes {
     ///   - id: Unique identifier of the `TaxID` object to delete.
     ///   - customer: ID of the customer.
     /// - Returns: A `StripeDeletedObject`.
-    func delete(id: String, customer: String) -> EventLoopFuture<StripeDeletedObject>
+    func delete(id: String, customer: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject>
     
     /// Returns a list of tax IDs for a customer.
     ///
@@ -45,7 +47,7 @@ public protocol CustomerTaxIDRoutes {
     ///   - customer: ID of the customer whose tax IDs will be retrieved.
     ///   - filter: A dictionary that will be used for the query parameters. [See More →](https://stripe.com/docs/api/customer_tax_ids/list).
     /// - Returns: A `StripeTaxIDList`.
-    func listAll(customer: String, filter: [String: Any]?) -> EventLoopFuture<StripeTaxIDList>
+    func listAll(customer: String, filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeTaxIDList>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
@@ -61,7 +63,7 @@ public struct StripeCustomerTaxIDRoutes: CustomerTaxIDRoutes {
         self.apiHandler = apiHandler
     }
     
-    public func create(customer: String, type: StripeTaxIDType, value: String, expand: [String]?) -> EventLoopFuture<StripeTaxID> {
+    public func create(customer: String, type: StripeTaxIDType, value: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeTaxID> {
         var body: [String: Any] = ["type": type.rawValue,
                                    "value": value]
         
@@ -72,7 +74,7 @@ public struct StripeCustomerTaxIDRoutes: CustomerTaxIDRoutes {
         return apiHandler.send(method: .POST, path: "\(taxids)/\(customer)/tax_ids", body: .string(body.queryParameters), headers: headers)
     }
     
-    public func retrieve(id: String, customer: String, expand: [String]?) -> EventLoopFuture<StripeTaxID> {
+    public func retrieve(id: String, customer: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeTaxID> {
         var queryParams = ""
         if let expand = expand {
             queryParams = ["expand": expand].queryParameters
@@ -80,11 +82,11 @@ public struct StripeCustomerTaxIDRoutes: CustomerTaxIDRoutes {
         return apiHandler.send(method: .GET, path: "\(taxids)/\(customer)/tax_ids/\(id)", query: queryParams, headers: headers)
     }
     
-    public func delete(id: String, customer: String) -> EventLoopFuture<StripeDeletedObject> {
+    public func delete(id: String, customer: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
         return apiHandler.send(method: .DELETE, path: "\(taxids)/\(customer)/tax_ids/\(id)", headers: headers)
     }
     
-    public func listAll(customer: String, filter: [String: Any]? = nil) -> EventLoopFuture<StripeTaxIDList> {
+    public func listAll(customer: String, filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeTaxIDList> {
         var queryParams = ""
         if let filter = filter {
             queryParams = filter.queryParameters

--- a/Sources/StripeKit/Billing/Discounts/DiscountRoutes.swift
+++ b/Sources/StripeKit/Billing/Discounts/DiscountRoutes.swift
@@ -38,10 +38,10 @@ public struct StripeDiscountRoutes: DiscountRoutes {
     }
     
     public func delete(customer: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
-        return apiHandler.send(method: .DELETE, path: "\(customers)/\(customer)/discount", headers: headers)
+        return apiHandler.send(method: .DELETE, path: "\(customers)/\(customer)/discount", headers: headers, context: context)
     }
     
     public func delete(subscription: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
-        return apiHandler.send(method: .DELETE, path: "\(subscriptions)/\(subscription)/discount", headers: headers)
+        return apiHandler.send(method: .DELETE, path: "\(subscriptions)/\(subscription)/discount", headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Billing/Discounts/DiscountRoutes.swift
+++ b/Sources/StripeKit/Billing/Discounts/DiscountRoutes.swift
@@ -7,19 +7,20 @@
 
 import NIO
 import NIOHTTP1
+import Baggage
 
 public protocol DiscountRoutes {
     /// Removes the currently applied discount on a customer.
     ///
     /// - Parameter customer: The id of the customer this discount belongs to.
     /// - Returns: A `StripeDeletedObject`.
-    func delete(customer: String) -> EventLoopFuture<StripeDeletedObject>
+    func delete(customer: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject>
     
     /// Removes the currently applied discount on a subscription.
     ///
     /// - Parameter subscription: The id of the subscription this discount was applied to.
     /// - Returns: A `StripeDeletedObject`.
-    func delete(subscription: String) -> EventLoopFuture<StripeDeletedObject>
+    func delete(subscription: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
@@ -36,11 +37,11 @@ public struct StripeDiscountRoutes: DiscountRoutes {
         self.apiHandler = apiHandler
     }
     
-    public func delete(customer: String) -> EventLoopFuture<StripeDeletedObject> {
+    public func delete(customer: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
         return apiHandler.send(method: .DELETE, path: "\(customers)/\(customer)/discount", headers: headers)
     }
     
-    public func delete(subscription: String) -> EventLoopFuture<StripeDeletedObject> {
+    public func delete(subscription: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
         return apiHandler.send(method: .DELETE, path: "\(subscriptions)/\(subscription)/discount", headers: headers)
     }
 }

--- a/Sources/StripeKit/Billing/Invoice Items/InvoiceItemRoutes.swift
+++ b/Sources/StripeKit/Billing/Invoice Items/InvoiceItemRoutes.swift
@@ -8,6 +8,7 @@
 
 import NIO
 import NIOHTTP1
+import Baggage
 
 public protocol InvoiceItemRoutes {
     /// Creates an item to be added to a draft invoice. If no invoice is specified, the item will be on the next invoice created for the customer specified.
@@ -45,7 +46,8 @@ public protocol InvoiceItemRoutes {
                 taxRates: [String]?,
                 unitAmount: Int?,
                 unitAmountDecimal: String?,
-                expand: [String]?) -> EventLoopFuture<StripeInvoiceItem>
+                expand: [String]?,
+                context: LoggingContext) -> EventLoopFuture<StripeInvoiceItem>
     
     /// Retrieves the invoice item with the given ID.
     ///
@@ -53,7 +55,7 @@ public protocol InvoiceItemRoutes {
     ///   - invoiceItem: The ID of the desired invoice item.
     ///   - expand: An array of properties to expand.
     /// - Returns: A `StripeInvoiceItem`.
-    func retrieve(invoiceItem: String, expand: [String]?) -> EventLoopFuture<StripeInvoiceItem>
+    func retrieve(invoiceItem: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeInvoiceItem>
     
     /// Updates the amount or description of an invoice item on an upcoming invoice. Updating an invoice item is only possible before the invoice it’s attached to is closed.
     ///
@@ -84,19 +86,20 @@ public protocol InvoiceItemRoutes {
                 taxRates: [String]?,
                 unitAmount: Int?,
                 unitAmountDecimal: String?,
-                expand: [String]?) -> EventLoopFuture<StripeInvoiceItem>
+                expand: [String]?,
+                context: LoggingContext) -> EventLoopFuture<StripeInvoiceItem>
     
     /// Deletes an invoice item, removing it from an invoice. Deleting invoice items is only possible when they’re not attached to invoices, or if it’s attached to a draft invoice.
     ///
     /// - Parameter invoiceItem: The identifier of the invoice item to be deleted.
     /// - Returns: A `StripeDeletedObject`.
-    func delete(invoiceItem: String) -> EventLoopFuture<StripeDeletedObject>
+    func delete(invoiceItem: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject>
     
     /// Returns a list of your invoice items. Invoice items are returned sorted by creation date, with the most recently created invoice items appearing first.
     ///
     /// - Parameter filter: A dictionary that will be used for the query parameters. [See More →](https://stripe.com/docs/api/invoiceitems/list)
     /// - Returns: A `StripeInvoiceItemList`
-    func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeInvoiceItemList>
+    func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeInvoiceItemList>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
@@ -118,7 +121,8 @@ extension InvoiceItemRoutes {
                        taxRates: [String]? = nil,
                        unitAmount: Int? = nil,
                        unitAmountDecimal: String? = nil,
-                       expand: [String]? = nil) -> EventLoopFuture<StripeInvoiceItem> {
+                       expand: [String]? = nil,
+                       context: LoggingContext) -> EventLoopFuture<StripeInvoiceItem> {
         return create(currency: currency,
                           customer: customer,
                           amount: amount,
@@ -137,7 +141,7 @@ extension InvoiceItemRoutes {
                           expand: expand)
     }
     
-    public func retrieve(invoiceItem: String, expand: [String]? = nil) -> EventLoopFuture<StripeInvoiceItem> {
+    public func retrieve(invoiceItem: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeInvoiceItem> {
         return retrieve(invoiceItem: invoiceItem, expand: expand)
     }
     
@@ -153,7 +157,8 @@ extension InvoiceItemRoutes {
                        taxRates: [String]? = nil,
                        unitAmount: Int? = nil,
                        unitAmountDecimal: String? = nil,
-                       expand: [String]? = nil) -> EventLoopFuture<StripeInvoiceItem> {
+                       expand: [String]? = nil,
+                       context: LoggingContext) -> EventLoopFuture<StripeInvoiceItem> {
         return update(invoiceItem: invoiceItem,
                           amount: amount,
                           description: description,
@@ -169,11 +174,11 @@ extension InvoiceItemRoutes {
                           expand: expand)
     }
     
-    public func delete(invoiceItem: String) -> EventLoopFuture<StripeDeletedObject> {
+    public func delete(invoiceItem: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
         return delete(invoiceItem: invoiceItem)
     }
     
-    public func listAll(filter: [String: Any]? = nil) -> EventLoopFuture<StripeInvoiceItemList> {
+    public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeInvoiceItemList> {
         return listAll(filter: filter)
     }
 }
@@ -203,7 +208,8 @@ public struct StripeInvoiceItemRoutes: InvoiceItemRoutes {
                        taxRates: [String]?,
                        unitAmount: Int?,
                        unitAmountDecimal: String?,
-                       expand: [String]?) -> EventLoopFuture<StripeInvoiceItem> {
+                       expand: [String]?,
+                       context: LoggingContext) -> EventLoopFuture<StripeInvoiceItem> {
         var body: [String: Any] = ["currency": currency.rawValue,
                                    "customer": customer]
         
@@ -266,7 +272,7 @@ public struct StripeInvoiceItemRoutes: InvoiceItemRoutes {
         return apiHandler.send(method: .POST, path: invoiceitems, body: .string(body.queryParameters), headers: headers)
     }
     
-    public func retrieve(invoiceItem: String, expand: [String]?) -> EventLoopFuture<StripeInvoiceItem> {
+    public func retrieve(invoiceItem: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeInvoiceItem> {
         var queryParams = ""
         if let expand = expand {
             queryParams = ["expand": expand].queryParameters
@@ -287,7 +293,8 @@ public struct StripeInvoiceItemRoutes: InvoiceItemRoutes {
                        taxRates: [String]?,
                        unitAmount: Int?,
                        unitAmountDecimal: String?,
-                       expand: [String]?) -> EventLoopFuture<StripeInvoiceItem> {
+                       expand: [String]?,
+                       context: LoggingContext) -> EventLoopFuture<StripeInvoiceItem> {
         var body: [String: Any] = [:]
         
         if let amount = amount {
@@ -341,11 +348,11 @@ public struct StripeInvoiceItemRoutes: InvoiceItemRoutes {
         return apiHandler.send(method: .POST, path: "\(invoiceitems)/\(invoiceItem)", body: .string(body.queryParameters), headers: headers)
     }
     
-    public func delete(invoiceItem: String) -> EventLoopFuture<StripeDeletedObject> {
+    public func delete(invoiceItem: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
         return apiHandler.send(method: .DELETE, path: "\(invoiceitems)/\(invoiceItem)", headers: headers)
     }
     
-    public func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeInvoiceItemList> {
+    public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeInvoiceItemList> {
         var queryParams = ""
         if let filter = filter {
             queryParams = filter.queryParameters

--- a/Sources/StripeKit/Billing/Invoice Items/InvoiceItemRoutes.swift
+++ b/Sources/StripeKit/Billing/Invoice Items/InvoiceItemRoutes.swift
@@ -138,11 +138,12 @@ extension InvoiceItemRoutes {
                           taxRates: taxRates,
                           unitAmount: unitAmount,
                           unitAmountDecimal: unitAmountDecimal,
-                          expand: expand)
+                          expand: expand,
+                      context: context)
     }
     
     public func retrieve(invoiceItem: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeInvoiceItem> {
-        return retrieve(invoiceItem: invoiceItem, expand: expand)
+        return retrieve(invoiceItem: invoiceItem, expand: expand, context: context)
     }
     
     public func update(invoiceItem: String,
@@ -171,15 +172,16 @@ extension InvoiceItemRoutes {
                           taxRates: taxRates,
                           unitAmount: unitAmount,
                           unitAmountDecimal: unitAmountDecimal,
-                          expand: expand)
+                          expand: expand,
+                      context: context)
     }
     
     public func delete(invoiceItem: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
-        return delete(invoiceItem: invoiceItem)
+        return delete(invoiceItem: invoiceItem, context: context)
     }
     
     public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeInvoiceItemList> {
-        return listAll(filter: filter)
+        return listAll(filter: filter, context: context)
     }
 }
 
@@ -269,7 +271,7 @@ public struct StripeInvoiceItemRoutes: InvoiceItemRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: invoiceitems, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: invoiceitems, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(invoiceItem: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeInvoiceItem> {
@@ -278,7 +280,7 @@ public struct StripeInvoiceItemRoutes: InvoiceItemRoutes {
             queryParams = ["expand": expand].queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: "\(invoiceitems)/\(invoiceItem)", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(invoiceitems)/\(invoiceItem)", query: queryParams, headers: headers, context: context)
     }
     
     public func update(invoiceItem: String,
@@ -345,11 +347,11 @@ public struct StripeInvoiceItemRoutes: InvoiceItemRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(invoiceitems)/\(invoiceItem)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(invoiceitems)/\(invoiceItem)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func delete(invoiceItem: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
-        return apiHandler.send(method: .DELETE, path: "\(invoiceitems)/\(invoiceItem)", headers: headers)
+        return apiHandler.send(method: .DELETE, path: "\(invoiceitems)/\(invoiceItem)", headers: headers, context: context)
     }
     
     public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeInvoiceItemList> {
@@ -358,6 +360,6 @@ public struct StripeInvoiceItemRoutes: InvoiceItemRoutes {
             queryParams = filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: invoiceitems, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: invoiceitems, query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Billing/Invoices/InvoiceRoutes.swift
+++ b/Sources/StripeKit/Billing/Invoices/InvoiceRoutes.swift
@@ -239,11 +239,12 @@ extension InvoiceRoutes {
                       statementDescriptor: statementDescriptor,
                       subscription: subscription,
                       transferData: transferData,
-                      expand: expand)
+                      expand: expand,
+                      context: context)
     }
     
     public func retrieve(invoice: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeInvoice> {
-        return retrieve(invoice: invoice, expand: expand)
+        return retrieve(invoice: invoice, expand: expand, context: context)
     }
     
     public func update(invoice: String,
@@ -284,15 +285,16 @@ extension InvoiceRoutes {
                       paymentSettings: paymentSettings,
                       statementDescriptor: statementDescriptor,
                       transferData: transferData,
-                      expand: expand)
+                      expand: expand,
+                      context: context)
     }
     
     public func delete(invoice: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
-        return delete(invoice: invoice)
+        return delete(invoice: invoice, context: context)
     }
     
     public func finalize(invoice: String, autoAdvance: Bool? = nil, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeInvoice> {
-        return finalize(invoice: invoice, autoAdvance: autoAdvance, expand: expand)
+        return finalize(invoice: invoice, autoAdvance: autoAdvance, expand: expand, context: context)
     }
     
     public func pay(invoice: String,
@@ -309,35 +311,36 @@ extension InvoiceRoutes {
                    paidOutOfBand: paidOutOfBand,
                    paymentMethod: paymentMethod,
                    source: source,
-                   expand: expand)
+                   expand: expand,
+                   context: context)
     }
     
     public func send(invoice: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeInvoice> {
-        return send(invoice: invoice, expand: expand)
+        return send(invoice: invoice, expand: expand, context: context)
     }
     
     public func void(invoice: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeInvoice> {
-        return void(invoice: invoice, expand: expand)
+        return void(invoice: invoice, expand: expand, context: context)
     }
     
     public func markUncollectible(invoice: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeInvoice> {
-        return markUncollectible(invoice: invoice, expand: expand)
+        return markUncollectible(invoice: invoice, expand: expand, context: context)
     }
     
     public func retrieveLineItems(invoice: String, filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeInvoiceLineItemList> {
-        return retrieveLineItems(invoice: invoice, filter: filter)
+        return retrieveLineItems(invoice: invoice, filter: filter, context: context)
     }
     
     public func retrieveUpcomingInvoice(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeInvoice> {
-        return retrieveUpcomingInvoice(filter: filter)
+        return retrieveUpcomingInvoice(filter: filter, context: context)
     }
     
     public func retrieveUpcomingLineItems(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeInvoiceLineItemList> {
-        return retrieveUpcomingLineItems(filter: filter)
+        return retrieveUpcomingLineItems(filter: filter, context: context)
     }
     
     public func listAll(filter: [String : Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeInvoiceList> {
-        return listAll(filter: filter)
+        return listAll(filter: filter, context: context)
     }
 }
 
@@ -451,7 +454,7 @@ public struct StripeInvoiceRoutes: InvoiceRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: invoices, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: invoices, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(invoice: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeInvoice> {
@@ -460,7 +463,7 @@ public struct StripeInvoiceRoutes: InvoiceRoutes {
             queryParams = ["expand": expand].queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: "\(invoices)/\(invoice)", query: queryParams)
+        return apiHandler.send(method: .GET, path: "\(invoices)/\(invoice)", query: queryParams, context: context)
     }
     
     public func update(invoice: String,
@@ -557,11 +560,11 @@ public struct StripeInvoiceRoutes: InvoiceRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(invoices)/\(invoice)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(invoices)/\(invoice)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func delete(invoice: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
-        return apiHandler.send(method: .DELETE, path: "\(invoices)/\(invoice)", headers: headers)
+        return apiHandler.send(method: .DELETE, path: "\(invoices)/\(invoice)", headers: headers, context: context)
     }
     
     public func finalize(invoice: String, autoAdvance: Bool?, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeInvoice> {
@@ -575,7 +578,7 @@ public struct StripeInvoiceRoutes: InvoiceRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(invoices)/\(invoice)/finalize", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(invoices)/\(invoice)/finalize", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func pay(invoice: String,
@@ -612,7 +615,7 @@ public struct StripeInvoiceRoutes: InvoiceRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(invoices)/\(invoice)/pay", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(invoices)/\(invoice)/pay", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func send(invoice: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeInvoice> {
@@ -622,7 +625,7 @@ public struct StripeInvoiceRoutes: InvoiceRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(invoices)/\(invoice)/send", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(invoices)/\(invoice)/send", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func void(invoice: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeInvoice> {
@@ -632,7 +635,7 @@ public struct StripeInvoiceRoutes: InvoiceRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(invoices)/\(invoice)/void", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(invoices)/\(invoice)/void", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func markUncollectible(invoice: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeInvoice> {
@@ -642,7 +645,7 @@ public struct StripeInvoiceRoutes: InvoiceRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(invoices)/\(invoice)/mark_uncollectible", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(invoices)/\(invoice)/mark_uncollectible", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieveLineItems(invoice: String, filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeInvoiceLineItemList> {
@@ -651,7 +654,7 @@ public struct StripeInvoiceRoutes: InvoiceRoutes {
             queryParams = filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: "\(invoices)/\(invoice)/lines", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(invoices)/\(invoice)/lines", query: queryParams, headers: headers, context: context)
     }
     
     public func retrieveUpcomingInvoice(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeInvoice> {
@@ -660,7 +663,7 @@ public struct StripeInvoiceRoutes: InvoiceRoutes {
             queryParams = filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: "\(invoices)/upcoming", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(invoices)/upcoming", query: queryParams, headers: headers, context: context)
     }
     
     public func retrieveUpcomingLineItems(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeInvoiceLineItemList> {
@@ -669,7 +672,7 @@ public struct StripeInvoiceRoutes: InvoiceRoutes {
             queryParams = filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: "\(invoices)/upcoming/lines", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(invoices)/upcoming/lines", query: queryParams, headers: headers, context: context)
     }
     
     public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeInvoiceList> {
@@ -678,6 +681,6 @@ public struct StripeInvoiceRoutes: InvoiceRoutes {
             queryParams = filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: invoices, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: invoices, query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Billing/Plans/PlanRoutes.swift
+++ b/Sources/StripeKit/Billing/Plans/PlanRoutes.swift
@@ -134,11 +134,12 @@ extension PlanRoutes {
                       transformUsage: transformUsage,
                       trialPeriodDays: trialPeriodDays,
                       usageType: usageType,
-                      expand: expand)
+                      expand: expand,
+                      context: context)
     }
     
     public func retrieve(plan: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripePlan> {
-        return retrieve(plan: plan, expand: expand)
+        return retrieve(plan: plan, expand: expand, context: context)
     }
     
     public func update(plan: String,
@@ -155,15 +156,16 @@ extension PlanRoutes {
                       nickname: nickname,
                       product: product,
                       trialPeriodDays: trialPeriodDays,
-                      expand: expand)
+                      expand: expand,
+                      context: context)
     }
     
     public func delete(plan: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
-        return delete(plan: plan)
+        return delete(plan: plan, context: context)
     }
     
     public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripePlanList> {
-        return listAll(filter: filter)
+        return listAll(filter: filter, context: context)
     }
 }
 
@@ -262,7 +264,7 @@ public struct StripePlanRoutes: PlanRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: plans, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: plans, body: .string(body.queryParameters), headers: headers, context: context)
     }
 
     public func retrieve(plan: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripePlan> {
@@ -271,7 +273,7 @@ public struct StripePlanRoutes: PlanRoutes {
             queryParams = ["expand": expand].queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: "\(plans)/\(plan)", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(plans)/\(plan)", query: queryParams, headers: headers, context: context)
     }
     
     public func update(plan: String,
@@ -310,11 +312,11 @@ public struct StripePlanRoutes: PlanRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(plans)/\(plan)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(plans)/\(plan)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func delete(plan: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
-        return apiHandler.send(method: .DELETE, path: "\(plans)/\(plan)", headers: headers)
+        return apiHandler.send(method: .DELETE, path: "\(plans)/\(plan)", headers: headers, context: context)
     }
     
     public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripePlanList> {
@@ -323,6 +325,6 @@ public struct StripePlanRoutes: PlanRoutes {
             queryParams = filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: plans, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: plans, query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Billing/Promotion Codes/PromotionCodesRoutes.swift
+++ b/Sources/StripeKit/Billing/Promotion Codes/PromotionCodesRoutes.swift
@@ -8,6 +8,7 @@
 import NIO
 import NIOHTTP1
 import Foundation
+import Baggage
 
 public protocol PromotionCodesRoutes {
     
@@ -28,7 +29,8 @@ public protocol PromotionCodesRoutes {
                 customer: String?,
                 expiresAt: Date?,
                 maxRedemptions: Int?,
-                restrictions: [String: Any]?) -> EventLoopFuture<StripePromotionCode>
+                restrictions: [String: Any]?,
+                context: LoggingContext) -> EventLoopFuture<StripePromotionCode>
     
     /// Updates the specified promotion code by setting the values of the parameters passed. Most fields are, by design, not editable.
     /// - Parameters:
@@ -37,15 +39,16 @@ public protocol PromotionCodesRoutes {
     ///   - active: Whether the promotion code is currently active. A promotion code can only be reactivated when the coupon is still valid and the promotion code is otherwise redeemable.
     func update(promotionCode: String,
                 metadata: [String: String]?,
-                active: Bool?) -> EventLoopFuture<StripePromotionCode>
+                active: Bool?,
+                context: LoggingContext) -> EventLoopFuture<StripePromotionCode>
     
     /// Retrieves the promotion code with the given ID.
     /// - Parameter promotionCode: The identifier of the promotion code to retrieve.
-    func retrieve(promotionCode: String) -> EventLoopFuture<StripePromotionCode>
+    func retrieve(promotionCode: String, context: LoggingContext) -> EventLoopFuture<StripePromotionCode>
     
     /// Returns a list of your promotion codes.
     /// - Parameter filter: A dictionary that will be used for the query parameters.
-    func listAll(filter: [String: Any]?) -> EventLoopFuture<StripePromotionCodeList>
+    func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripePromotionCodeList>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
@@ -59,7 +62,8 @@ extension PromotionCodesRoutes {
                        customer: String? = nil,
                        expiresAt: Date? = nil,
                        maxRedemptions: Int? = nil,
-                       restrictions: [String: Any]? = nil) -> EventLoopFuture<StripePromotionCode> {
+                       restrictions: [String: Any]? = nil,
+                       context: LoggingContext) -> EventLoopFuture<StripePromotionCode> {
         create(coupon: coupon,
                code: code,
                metadata: metadata,
@@ -72,15 +76,16 @@ extension PromotionCodesRoutes {
     
     public func update(promotionCode: String,
                        metadata: [String: String]? = nil,
-                       active: Bool? = nil) -> EventLoopFuture<StripePromotionCode> {
+                       active: Bool? = nil,
+                       context: LoggingContext) -> EventLoopFuture<StripePromotionCode> {
         update(promotionCode: promotionCode, metadata: metadata, active: active)
     }
     
-    public func retrieve(promotionCode: String) -> EventLoopFuture<StripePromotionCode> {
+    public func retrieve(promotionCode: String, context: LoggingContext) -> EventLoopFuture<StripePromotionCode> {
         retrieve(promotionCode: promotionCode)
     }
     
-    public func listAll(filter: [String: Any]? = nil) -> EventLoopFuture<StripePromotionCodeList> {
+    public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripePromotionCodeList> {
         listAll(filter: filter)
     }
 }
@@ -102,7 +107,8 @@ public struct StripePromotionCodesRoutes: PromotionCodesRoutes {
                        customer: String?,
                        expiresAt: Date?,
                        maxRedemptions: Int?,
-                       restrictions: [String: Any]?) -> EventLoopFuture<StripePromotionCode> {
+                       restrictions: [String: Any]?,
+                       context: LoggingContext) -> EventLoopFuture<StripePromotionCode> {
         var body: [String: Any] = ["coupon": coupon]
         
         if let code = code {
@@ -138,7 +144,8 @@ public struct StripePromotionCodesRoutes: PromotionCodesRoutes {
     
     public func update(promotionCode: String,
                        metadata: [String: String]?,
-                       active: Bool?) -> EventLoopFuture<StripePromotionCode> {
+                       active: Bool?,
+                       context: LoggingContext) -> EventLoopFuture<StripePromotionCode> {
         var body: [String: Any] = [:]
         
         if let active = active {
@@ -152,11 +159,11 @@ public struct StripePromotionCodesRoutes: PromotionCodesRoutes {
         return apiHandler.send(method: .POST, path: "\(promotionCodes)/\(promotionCode)", body: .string(body.queryParameters), headers: headers)
     }
     
-    public func retrieve(promotionCode: String) -> EventLoopFuture<StripePromotionCode> {
+    public func retrieve(promotionCode: String, context: LoggingContext) -> EventLoopFuture<StripePromotionCode> {
         apiHandler.send(method: .GET, path: "\(promotionCodes)/\(promotionCode)", headers: headers)
     }
     
-    public func listAll(filter: [String: Any]?) -> EventLoopFuture<StripePlanList> {
+    public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripePlanList> {
         var queryParams = ""
         if let filter = filter {
             queryParams = filter.queryParameters

--- a/Sources/StripeKit/Billing/Promotion Codes/PromotionCodesRoutes.swift
+++ b/Sources/StripeKit/Billing/Promotion Codes/PromotionCodesRoutes.swift
@@ -71,22 +71,23 @@ extension PromotionCodesRoutes {
                customer: customer,
                expiresAt: expiresAt,
                maxRedemptions: maxRedemptions,
-               restrictions: restrictions)
+               restrictions: restrictions,
+               context: context)
     }
     
     public func update(promotionCode: String,
                        metadata: [String: String]? = nil,
                        active: Bool? = nil,
                        context: LoggingContext) -> EventLoopFuture<StripePromotionCode> {
-        update(promotionCode: promotionCode, metadata: metadata, active: active)
+        update(promotionCode: promotionCode, metadata: metadata, active: active, context: context)
     }
     
     public func retrieve(promotionCode: String, context: LoggingContext) -> EventLoopFuture<StripePromotionCode> {
-        retrieve(promotionCode: promotionCode)
+        retrieve(promotionCode: promotionCode, context: context)
     }
     
     public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripePromotionCodeList> {
-        listAll(filter: filter)
+        listAll(filter: filter, context: context)
     }
 }
 
@@ -139,7 +140,7 @@ public struct StripePromotionCodesRoutes: PromotionCodesRoutes {
             restrictions.forEach { body["restrictions[\($0)]"] = $1 }
         }
         
-        return apiHandler.send(method: .POST, path: promotionCodes, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: promotionCodes, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func update(promotionCode: String,
@@ -156,11 +157,11 @@ public struct StripePromotionCodesRoutes: PromotionCodesRoutes {
             metadata.forEach { body["metadata[\($0)]"] = $1 }
         }
         
-        return apiHandler.send(method: .POST, path: "\(promotionCodes)/\(promotionCode)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(promotionCodes)/\(promotionCode)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(promotionCode: String, context: LoggingContext) -> EventLoopFuture<StripePromotionCode> {
-        apiHandler.send(method: .GET, path: "\(promotionCodes)/\(promotionCode)", headers: headers)
+        apiHandler.send(method: .GET, path: "\(promotionCodes)/\(promotionCode)", headers: headers, context: context)
     }
     
     public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripePlanList> {
@@ -169,6 +170,6 @@ public struct StripePromotionCodesRoutes: PromotionCodesRoutes {
             queryParams = filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: promotionCodes, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: promotionCodes, query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Billing/Subscription Items/SubscriptionItemRoutes.swift
+++ b/Sources/StripeKit/Billing/Subscription Items/SubscriptionItemRoutes.swift
@@ -9,6 +9,7 @@
 import NIO
 import NIOHTTP1
 import Foundation
+import Baggage
 
 public protocol SubscriptionItemRoutes {
     /// Adds a new item to an existing subscription. No existing items will be changed or replaced.
@@ -36,13 +37,14 @@ public protocol SubscriptionItemRoutes {
                 prorationBehavior: StripeSubscriptionItemProrationBehavior?,
                 prorationDate: Date?,
                 quantity: Int?,
-                taxRates: [String]?) -> EventLoopFuture<StripeSubscriptionItem>
+                taxRates: [String]?,
+                context: LoggingContext) -> EventLoopFuture<StripeSubscriptionItem>
     
     /// Retrieves the invoice item with the given ID.
     ///
     /// - Parameter item: The identifier of the subscription item to retrieve.
     /// - Returns: A `StripeSubscriptionItem`.
-    func retrieve(item: String) -> EventLoopFuture<StripeSubscriptionItem>
+    func retrieve(item: String, context: LoggingContext) -> EventLoopFuture<StripeSubscriptionItem>
     
     /// Updates the plan or quantity of an item on a current subscription.
     ///
@@ -71,7 +73,8 @@ public protocol SubscriptionItemRoutes {
                 prorationBehavior: StripeSubscriptionItemProrationBehavior?,
                 prorationDate: Date?,
                 quantity: Int?,
-                taxRates: [String]?) -> EventLoopFuture<StripeSubscriptionItem>
+                taxRates: [String]?,
+                context: LoggingContext) -> EventLoopFuture<StripeSubscriptionItem>
     
     /// Deletes an item from the subscription. Removing a subscription item from a subscription will not cancel the subscription.
     ///
@@ -84,7 +87,8 @@ public protocol SubscriptionItemRoutes {
     func delete(item: String,
                 clearUsage: Bool?,
                 prorationBehavior: StripeSubscriptionItemProrationBehavior?,
-                prorationDate: Date?) -> EventLoopFuture<StripeSubscriptionItem>
+                prorationDate: Date?,
+                context: LoggingContext) -> EventLoopFuture<StripeSubscriptionItem>
     
     /// Returns a list of your subscription items for a given subscription.
     ///
@@ -92,7 +96,7 @@ public protocol SubscriptionItemRoutes {
     ///   - subscription: The ID of the subscription whose items will be retrieved.
     ///   - filter: A dictionary that will be used for the query parameters. [See More →](https://stripe.com/docs/api/subscription_items/list)
     /// - Returns: A `StripeSubscriptionItemList`.
-    func listAll(subscription: String, filter: [String: Any]?) -> EventLoopFuture<StripeSubscriptionItemList>
+    func listAll(subscription: String, filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeSubscriptionItemList>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
@@ -109,7 +113,8 @@ extension SubscriptionItemRoutes {
                        prorationBehavior: StripeSubscriptionItemProrationBehavior? = nil,
                        prorationDate: Date? = nil,
                        quantity: Int? = nil,
-                       taxRates: [String]? = nil) -> EventLoopFuture<StripeSubscriptionItem> {
+                       taxRates: [String]? = nil,
+                       context: LoggingContext) -> EventLoopFuture<StripeSubscriptionItem> {
         return create(plan: plan,
                       subscription: subscription,
                       billingThresholds: billingThresholds,
@@ -123,7 +128,7 @@ extension SubscriptionItemRoutes {
                       taxRates: taxRates)
     }
     
-    public func retrieve(item: String) -> EventLoopFuture<StripeSubscriptionItem> {
+    public func retrieve(item: String, context: LoggingContext) -> EventLoopFuture<StripeSubscriptionItem> {
         return retrieve(item: item)
     }
     
@@ -138,7 +143,8 @@ extension SubscriptionItemRoutes {
                        prorationBehavior: StripeSubscriptionItemProrationBehavior? = nil,
                        prorationDate: Date? = nil,
                        quantity: Int? = nil,
-                       taxRates: [String]? = nil) -> EventLoopFuture<StripeSubscriptionItem> {
+                       taxRates: [String]? = nil,
+                       context: LoggingContext) -> EventLoopFuture<StripeSubscriptionItem> {
         return update(item: item,
                       billingThresholds: billingThresholds,
                       metadata: metadata,
@@ -156,14 +162,15 @@ extension SubscriptionItemRoutes {
     public func delete(item: String,
                        clearUsage: Bool? = nil,
                        prorationBehavior: StripeSubscriptionItemProrationBehavior? = nil,
-                       prorationDate: Date? = nil) -> EventLoopFuture<StripeSubscriptionItem> {
+                       prorationDate: Date? = nil,
+                       context: LoggingContext) -> EventLoopFuture<StripeSubscriptionItem> {
         return delete(item: item,
                       clearUsage: clearUsage,
                       prorationBehavior: prorationBehavior,
                       prorationDate: prorationDate)
     }
     
-    public func listAll(subscription: String, filter: [String: Any]? = nil) -> EventLoopFuture<StripeSubscriptionItemList> {
+    public func listAll(subscription: String, filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeSubscriptionItemList> {
         return listAll(subscription: subscription, filter: filter)
     }
 }
@@ -188,7 +195,8 @@ public struct StripeSubscriptionItemRoutes: SubscriptionItemRoutes {
                        prorationBehavior: StripeSubscriptionItemProrationBehavior?,
                        prorationDate: Date?,
                        quantity: Int?,
-                       taxRates: [String]?) -> EventLoopFuture<StripeSubscriptionItem> {
+                       taxRates: [String]?,
+                       context: LoggingContext) -> EventLoopFuture<StripeSubscriptionItem> {
         var body: [String: Any] = ["plan": plan,
                                    "subscription": subscription]
         
@@ -231,7 +239,7 @@ public struct StripeSubscriptionItemRoutes: SubscriptionItemRoutes {
         return apiHandler.send(method: .POST, path: subscirptionitems, body: .string(body.queryParameters), headers: headers)
     }
     
-    public func retrieve(item: String) -> EventLoopFuture<StripeSubscriptionItem> {
+    public func retrieve(item: String, context: LoggingContext) -> EventLoopFuture<StripeSubscriptionItem> {
         return apiHandler.send(method: .GET, path: "\(subscirptionitems)/\(item)", headers: headers)
     }
     
@@ -246,7 +254,8 @@ public struct StripeSubscriptionItemRoutes: SubscriptionItemRoutes {
                        prorationBehavior: StripeSubscriptionItemProrationBehavior?,
                        prorationDate: Date?,
                        quantity: Int?,
-                       taxRates: [String]?) -> EventLoopFuture<StripeSubscriptionItem> {
+                       taxRates: [String]?,
+                       context: LoggingContext) -> EventLoopFuture<StripeSubscriptionItem> {
         var body: [String: Any] = [:]
         
         if let billingThresholds = billingThresholds {
@@ -299,7 +308,8 @@ public struct StripeSubscriptionItemRoutes: SubscriptionItemRoutes {
     public func delete(item: String,
                        clearUsage: Bool?,
                        prorationBehavior: StripeSubscriptionItemProrationBehavior?,
-                       prorationDate: Date?) -> EventLoopFuture<StripeSubscriptionItem> {
+                       prorationDate: Date?,
+                       context: LoggingContext) -> EventLoopFuture<StripeSubscriptionItem> {
         var body: [String: Any] = [:]
         
         if let clearUsage = clearUsage {
@@ -317,7 +327,7 @@ public struct StripeSubscriptionItemRoutes: SubscriptionItemRoutes {
         return apiHandler.send(method: .DELETE, path: "\(subscirptionitems)/\(item)", body: .string(body.queryParameters), headers: headers)
     }
     
-    public func listAll(subscription: String, filter: [String: Any]?) -> EventLoopFuture<StripeSubscriptionItemList> {
+    public func listAll(subscription: String, filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeSubscriptionItemList> {
         var queryParams = "subscription=\(subscription)"
         if let filter = filter {
             queryParams += "&" + filter.queryParameters

--- a/Sources/StripeKit/Billing/Subscription Items/SubscriptionItemRoutes.swift
+++ b/Sources/StripeKit/Billing/Subscription Items/SubscriptionItemRoutes.swift
@@ -125,11 +125,12 @@ extension SubscriptionItemRoutes {
                       prorationBehavior: prorationBehavior,
                       prorationDate: prorationDate,
                       quantity: quantity,
-                      taxRates: taxRates)
+                      taxRates: taxRates,
+                      context: context)
     }
     
     public func retrieve(item: String, context: LoggingContext) -> EventLoopFuture<StripeSubscriptionItem> {
-        return retrieve(item: item)
+        return retrieve(item: item, context: context)
     }
     
     public func update(item: String,
@@ -156,7 +157,8 @@ extension SubscriptionItemRoutes {
                       prorationBehavior: prorationBehavior,
                       prorationDate: prorationDate,
                       quantity: quantity,
-                      taxRates: taxRates)
+                      taxRates: taxRates,
+                      context: context)
     }
     
     public func delete(item: String,
@@ -167,11 +169,12 @@ extension SubscriptionItemRoutes {
         return delete(item: item,
                       clearUsage: clearUsage,
                       prorationBehavior: prorationBehavior,
-                      prorationDate: prorationDate)
+                      prorationDate: prorationDate,
+                      context: context)
     }
     
     public func listAll(subscription: String, filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeSubscriptionItemList> {
-        return listAll(subscription: subscription, filter: filter)
+        return listAll(subscription: subscription, filter: filter, context: context)
     }
 }
 
@@ -236,11 +239,11 @@ public struct StripeSubscriptionItemRoutes: SubscriptionItemRoutes {
             body["tax_rates"] = taxRates
         }
         
-        return apiHandler.send(method: .POST, path: subscirptionitems, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: subscirptionitems, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(item: String, context: LoggingContext) -> EventLoopFuture<StripeSubscriptionItem> {
-        return apiHandler.send(method: .GET, path: "\(subscirptionitems)/\(item)", headers: headers)
+        return apiHandler.send(method: .GET, path: "\(subscirptionitems)/\(item)", headers: headers, context: context)
     }
     
     public func update(item: String,
@@ -302,7 +305,7 @@ public struct StripeSubscriptionItemRoutes: SubscriptionItemRoutes {
             body["tax_rates"] = taxRates
         }
 
-        return apiHandler.send(method: .POST, path: "\(subscirptionitems)/\(item)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(subscirptionitems)/\(item)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func delete(item: String,
@@ -324,7 +327,7 @@ public struct StripeSubscriptionItemRoutes: SubscriptionItemRoutes {
             body["proration_date"] = Int(prorationDate.timeIntervalSince1970)
         }
 
-        return apiHandler.send(method: .DELETE, path: "\(subscirptionitems)/\(item)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .DELETE, path: "\(subscirptionitems)/\(item)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func listAll(subscription: String, filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeSubscriptionItemList> {
@@ -333,6 +336,6 @@ public struct StripeSubscriptionItemRoutes: SubscriptionItemRoutes {
             queryParams += "&" + filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: subscirptionitems, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: subscirptionitems, query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Billing/Subscription Schedule/SubscriptionScheduleRoutes.swift
+++ b/Sources/StripeKit/Billing/Subscription Schedule/SubscriptionScheduleRoutes.swift
@@ -98,11 +98,11 @@ extension SubscriptionScheduleRoutes {
                       metadata: metadata,
                       phases: phases,
                       startDate: startDate,
-                      expand: expand)
+                      expand: expand, context: context)
     }
     
     public func retrieve(schedule: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeSubscriptionSchedule> {
-        return retrieve(schedule: schedule, expand: expand)
+        return retrieve(schedule: schedule, expand: expand, context: context)
     }
     
     public func update(schedule: String,
@@ -119,7 +119,7 @@ extension SubscriptionScheduleRoutes {
                       metadata: metadata,
                       phases: phases,
                       prorationBehavior: prorationBehavior,
-                      expand: expand)
+                      expand: expand, context: context)
     }
     
     public func cancel(schedule: String,
@@ -130,7 +130,7 @@ extension SubscriptionScheduleRoutes {
         return cancel(schedule: schedule,
                       invoiceNow: invoiceNow,
                       prorate: prorate,
-                      expand: expand)
+                      expand: expand, context: context)
     }
     
     public func release(schedule: String,
@@ -139,11 +139,11 @@ extension SubscriptionScheduleRoutes {
                         context: LoggingContext) -> EventLoopFuture<StripeSubscriptionSchedule> {
         return release(schedule: schedule,
                        preserveCancelDate: preserveCancelDate,
-                       expand: expand)
+                       expand: expand, context: context)
     }
     
     public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeSubscriptionScheduleList> {
-        return listAll(filter: filter)
+        return listAll(filter: filter, context: context)
     }
 }
 
@@ -200,7 +200,7 @@ public struct StripeSubscriptionScheduleRoutes: SubscriptionScheduleRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: subscriptionschedules, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: subscriptionschedules, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(schedule: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeSubscriptionSchedule> {
@@ -209,7 +209,7 @@ public struct StripeSubscriptionScheduleRoutes: SubscriptionScheduleRoutes {
             queryParams = ["expand": expand].queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: "\(subscriptionschedules)/\(schedule)", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(subscriptionschedules)/\(schedule)", query: queryParams, headers: headers, context: context)
     }
     
     public func update(schedule: String,
@@ -246,7 +246,7 @@ public struct StripeSubscriptionScheduleRoutes: SubscriptionScheduleRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(subscriptionschedules)/\(schedule)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(subscriptionschedules)/\(schedule)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func cancel(schedule: String,
@@ -268,7 +268,7 @@ public struct StripeSubscriptionScheduleRoutes: SubscriptionScheduleRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(subscriptionschedules)/\(schedule)/cancel", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(subscriptionschedules)/\(schedule)/cancel", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func release(schedule: String, preserveCancelDate: Bool?, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeSubscriptionSchedule> {
@@ -282,7 +282,7 @@ public struct StripeSubscriptionScheduleRoutes: SubscriptionScheduleRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(subscriptionschedules)/\(schedule)/release", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(subscriptionschedules)/\(schedule)/release", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeSubscriptionScheduleList> {
@@ -291,6 +291,6 @@ public struct StripeSubscriptionScheduleRoutes: SubscriptionScheduleRoutes {
             queryParams = filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: subscriptionschedules, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: subscriptionschedules, query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Billing/Subscription Schedule/SubscriptionScheduleRoutes.swift
+++ b/Sources/StripeKit/Billing/Subscription Schedule/SubscriptionScheduleRoutes.swift
@@ -8,6 +8,7 @@
 import NIO
 import NIOHTTP1
 import Foundation
+import Baggage
 
 public protocol SubscriptionScheduleRoutes {
     /// Creates a new subscription schedule object.
@@ -26,13 +27,14 @@ public protocol SubscriptionScheduleRoutes {
                 metadata: [String: String]?,
                 phases: [[String: Any]]?,
                 startDate: Date?,
-                expand: [String]?) -> EventLoopFuture<StripeSubscriptionSchedule>
+                expand: [String]?,
+                context: LoggingContext) -> EventLoopFuture<StripeSubscriptionSchedule>
     
     /// Retrieves the details of an existing subscription schedule. You only need to supply the unique subscription schedule identifier that was returned upon subscription schedule creation.
     /// - Parameters:
     ///   - schedule: The identifier of the subscription schedule to be retrieved.
     ///   - expand: An array of properties to expand.
-    func retrieve(schedule: String, expand: [String]?) -> EventLoopFuture<StripeSubscriptionSchedule>
+    func retrieve(schedule: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeSubscriptionSchedule>
     
     /// Updates an existing subscription schedule.
     /// - Parameter schedule: The identifier of the subscription schedule to be updated.
@@ -48,7 +50,8 @@ public protocol SubscriptionScheduleRoutes {
                 metadata: [String: String]?,
                 phases: [[String: Any]]?,
                 prorationBehavior: StripeSubscriptionSchedulePhaseProrationBehavior?,
-                expand: [String]?) -> EventLoopFuture<StripeSubscriptionSchedule>
+                expand: [String]?,
+                context: LoggingContext) -> EventLoopFuture<StripeSubscriptionSchedule>
     
     /// Cancels a subscription schedule and its associated subscription immediately (if the subscription schedule has an active subscription). A subscription schedule can only be canceled if its status is `not_started` or `active`.
     /// - Parameter schedule: The identifier of the subscription schedule to be canceled.
@@ -58,7 +61,8 @@ public protocol SubscriptionScheduleRoutes {
     func cancel(schedule: String,
                 invoiceNow: Bool?,
                 prorate: Bool?,
-                expand: [String]?) -> EventLoopFuture<StripeSubscriptionSchedule>
+                expand: [String]?,
+                context: LoggingContext) -> EventLoopFuture<StripeSubscriptionSchedule>
     
     /// Releases the subscription schedule immediately, which will stop scheduling of its phases, but leave any existing subscription in place. A schedule can only be released if its status is `not_started` or `active`. If the subscription schedule is currently associated with a subscription, releasing it will remove its `subscription` property and set the subscription’s ID to the `released_subscription` property.
     /// - Parameter schedule: The identifier of the subscription schedule to be released.
@@ -66,11 +70,12 @@ public protocol SubscriptionScheduleRoutes {
     /// - Parameter expand: An array of properties to expand.
     func release(schedule: String,
                  preserveCancelDate: Bool?,
-                 expand: [String]?) -> EventLoopFuture<StripeSubscriptionSchedule>
+                 expand: [String]?,
+                 context: LoggingContext) -> EventLoopFuture<StripeSubscriptionSchedule>
     
     /// Retrieves the list of your subscription schedules.
     /// - Parameter filter: A dictionary that will be used for the query parameters. [See More →](https://stripe.com/docs/api/subscription_schedules/list)
-    func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeSubscriptionScheduleList>
+    func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeSubscriptionScheduleList>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
@@ -84,7 +89,8 @@ extension SubscriptionScheduleRoutes {
                        metadata: [String: String]? = nil,
                        phases: [[String: Any]]? = nil,
                        startDate: Date? = nil,
-                       expand: [String]? = nil) -> EventLoopFuture<StripeSubscriptionSchedule> {
+                       expand: [String]? = nil,
+                       context: LoggingContext) -> EventLoopFuture<StripeSubscriptionSchedule> {
         return create(customer: customer,
                       defaultSettings: defaultSettings,
                       endBehavior: endBehavior,
@@ -95,7 +101,7 @@ extension SubscriptionScheduleRoutes {
                       expand: expand)
     }
     
-    public func retrieve(schedule: String, expand: [String]? = nil) -> EventLoopFuture<StripeSubscriptionSchedule> {
+    public func retrieve(schedule: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeSubscriptionSchedule> {
         return retrieve(schedule: schedule, expand: expand)
     }
     
@@ -105,7 +111,8 @@ extension SubscriptionScheduleRoutes {
                        metadata: [String: String]? = nil,
                        phases: [[String: Any]]? = nil,
                        prorationBehavior: StripeSubscriptionSchedulePhaseProrationBehavior? = nil,
-                       expand: [String]? = nil) -> EventLoopFuture<StripeSubscriptionSchedule> {
+                       expand: [String]? = nil,
+                       context: LoggingContext) -> EventLoopFuture<StripeSubscriptionSchedule> {
         return update(schedule: schedule,
                       defaultSettings: defaultSettings,
                       endBehavior: endBehavior,
@@ -118,7 +125,8 @@ extension SubscriptionScheduleRoutes {
     public func cancel(schedule: String,
                        invoiceNow: Bool? = nil,
                        prorate: Bool? = nil,
-                       expand: [String]? = nil) -> EventLoopFuture<StripeSubscriptionSchedule> {
+                       expand: [String]? = nil,
+                       context: LoggingContext) -> EventLoopFuture<StripeSubscriptionSchedule> {
         return cancel(schedule: schedule,
                       invoiceNow: invoiceNow,
                       prorate: prorate,
@@ -127,13 +135,14 @@ extension SubscriptionScheduleRoutes {
     
     public func release(schedule: String,
                         preserveCancelDate: Bool? = nil,
-                        expand: [String]? = nil) -> EventLoopFuture<StripeSubscriptionSchedule> {
+                        expand: [String]? = nil,
+                        context: LoggingContext) -> EventLoopFuture<StripeSubscriptionSchedule> {
         return release(schedule: schedule,
                        preserveCancelDate: preserveCancelDate,
                        expand: expand)
     }
     
-    public func listAll(filter: [String: Any]? = nil) -> EventLoopFuture<StripeSubscriptionScheduleList> {
+    public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeSubscriptionScheduleList> {
         return listAll(filter: filter)
     }
 }
@@ -155,7 +164,8 @@ public struct StripeSubscriptionScheduleRoutes: SubscriptionScheduleRoutes {
                        metadata: [String: String]?,
                        phases: [[String: Any]]?,
                        startDate: Date?,
-                       expand: [String]?) -> EventLoopFuture<StripeSubscriptionSchedule> {
+                       expand: [String]?,
+                       context: LoggingContext) -> EventLoopFuture<StripeSubscriptionSchedule> {
         var body: [String: Any] = [:]
         
         if let customer = customer {
@@ -193,7 +203,7 @@ public struct StripeSubscriptionScheduleRoutes: SubscriptionScheduleRoutes {
         return apiHandler.send(method: .POST, path: subscriptionschedules, body: .string(body.queryParameters), headers: headers)
     }
     
-    public func retrieve(schedule: String, expand: [String]?) -> EventLoopFuture<StripeSubscriptionSchedule> {
+    public func retrieve(schedule: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeSubscriptionSchedule> {
         var queryParams = ""
         if let expand = expand {
             queryParams = ["expand": expand].queryParameters
@@ -208,7 +218,8 @@ public struct StripeSubscriptionScheduleRoutes: SubscriptionScheduleRoutes {
                        metadata: [String: String]?,
                        phases: [[String: Any]]?,
                        prorationBehavior: StripeSubscriptionSchedulePhaseProrationBehavior?,
-                       expand: [String]?) -> EventLoopFuture<StripeSubscriptionSchedule> {
+                       expand: [String]?,
+                       context: LoggingContext) -> EventLoopFuture<StripeSubscriptionSchedule> {
         var body: [String: Any] = [:]
         
         if let defaultSettings = defaultSettings {
@@ -241,7 +252,8 @@ public struct StripeSubscriptionScheduleRoutes: SubscriptionScheduleRoutes {
     public func cancel(schedule: String,
                        invoiceNow: Bool?,
                        prorate: Bool?,
-                       expand: [String]?) -> EventLoopFuture<StripeSubscriptionSchedule> {
+                       expand: [String]?,
+                       context: LoggingContext) -> EventLoopFuture<StripeSubscriptionSchedule> {
         var body: [String: Any] = [:]
         
         if let invoiceNow = invoiceNow {
@@ -259,7 +271,7 @@ public struct StripeSubscriptionScheduleRoutes: SubscriptionScheduleRoutes {
         return apiHandler.send(method: .POST, path: "\(subscriptionschedules)/\(schedule)/cancel", body: .string(body.queryParameters), headers: headers)
     }
     
-    public func release(schedule: String, preserveCancelDate: Bool?, expand: [String]?) -> EventLoopFuture<StripeSubscriptionSchedule> {
+    public func release(schedule: String, preserveCancelDate: Bool?, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeSubscriptionSchedule> {
         var body: [String: Any] = [:]
         
         if let preserveCancelDate = preserveCancelDate {
@@ -273,7 +285,7 @@ public struct StripeSubscriptionScheduleRoutes: SubscriptionScheduleRoutes {
         return apiHandler.send(method: .POST, path: "\(subscriptionschedules)/\(schedule)/release", body: .string(body.queryParameters), headers: headers)
     }
     
-    public func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeSubscriptionScheduleList> {
+    public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeSubscriptionScheduleList> {
         var queryParams = ""
         if let filter = filter {
             queryParams = filter.queryParameters

--- a/Sources/StripeKit/Billing/Subscriptions/SubscriptionRoutes.swift
+++ b/Sources/StripeKit/Billing/Subscriptions/SubscriptionRoutes.swift
@@ -214,11 +214,12 @@ extension SubscriptionRoutes {
                       trialEnd: trialEnd,
                       trialFromPlan: trialFromPlan,
                       trialPeriodDays: trialPeriodDays,
-                      expand: expand)
+                      expand: expand,
+                      context: context)
     }
     
     public func retrieve(id: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeSubscription> {
-        return retrieve(id: id, expand: expand)
+        return retrieve(id: id, expand: expand, context: context)
     }
     
     public func update(subscription: String,
@@ -273,7 +274,8 @@ extension SubscriptionRoutes {
                       transferData: transferData,
                       trialEnd: trialEnd,
                       trialFromPlan: trialFromPlan,
-                      expand: expand)
+                      expand: expand,
+                      context: context)
     }
     
     public func cancel(subscription: String,
@@ -284,11 +286,12 @@ extension SubscriptionRoutes {
         return cancel(subscription: subscription,
                       invoiceNow: invoiceNow,
                       prorate: prorate,
-                      expand: expand)
+                      expand: expand,
+                      context: context)
     }
     
     public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeSubscriptionList> {
-        return listAll(filter: filter)
+        return listAll(filter: filter, context: context)
     }
 }
 
@@ -432,7 +435,7 @@ public struct StripeSubscriptionRoutes: SubscriptionRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: subscriptions, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: subscriptions, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(id: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeSubscription> {
@@ -440,7 +443,7 @@ public struct StripeSubscriptionRoutes: SubscriptionRoutes {
         if let expand = expand {
             queryParams = ["expand": expand].queryParameters
         }
-        return apiHandler.send(method: .GET, path: "\(subscriptions)/\(id)", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(subscriptions)/\(id)", query: queryParams, headers: headers, context: context)
     }
     
     public func update(subscription: String,
@@ -572,7 +575,7 @@ public struct StripeSubscriptionRoutes: SubscriptionRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(subscriptions)/\(subscription)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(subscriptions)/\(subscription)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func cancel(subscription: String,
@@ -594,7 +597,7 @@ public struct StripeSubscriptionRoutes: SubscriptionRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .DELETE, path: "\(subscriptions)/\(subscription)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .DELETE, path: "\(subscriptions)/\(subscription)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func listAll(filter: [String : Any]?, context: LoggingContext) -> EventLoopFuture<StripeSubscriptionList> {
@@ -603,6 +606,6 @@ public struct StripeSubscriptionRoutes: SubscriptionRoutes {
             queryParams = filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: subscriptions, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: subscriptions, query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Billing/Tax Rates/TaxRateRoutes.swift
+++ b/Sources/StripeKit/Billing/Tax Rates/TaxRateRoutes.swift
@@ -8,6 +8,7 @@
 import NIO
 import NIOHTTP1
 import Foundation
+import Baggage
 
 public protocol TaxRateRoutes {
     /// Creates a new tax rate.
@@ -31,13 +32,14 @@ public protocol TaxRateRoutes {
                 description: String?,
                 jurisdiction: String?,
                 metadata: [String: String]?,
-                state: String?) -> EventLoopFuture<StripeTaxRate>
+                state: String?,
+                context: LoggingContext) -> EventLoopFuture<StripeTaxRate>
     
     /// Retrieves a tax rate with the given ID
     ///
     /// - Parameter taxRate: The ID of the desired tax rate.
     /// - Returns: A `StripeTaxRate`.
-    func retrieve(taxRate: String) -> EventLoopFuture<StripeTaxRate>
+    func retrieve(taxRate: String, context: LoggingContext) -> EventLoopFuture<StripeTaxRate>
     
     /// Updates an existing tax rate.
     ///
@@ -58,13 +60,14 @@ public protocol TaxRateRoutes {
                 displayName: String?,
                 jurisdiction: String?,
                 metadata: [String: String]?,
-                state: String?) -> EventLoopFuture<StripeTaxRate>
+                state: String?,
+                context: LoggingContext) -> EventLoopFuture<StripeTaxRate>
     
     /// Returns a list of your tax rates. Tax rates are returned sorted by creation date, with the most recently created tax rates appearing first.
     ///
     /// - Parameter filter: A dictionary that will be used for the query parameters. [See More →](https://stripe.com/docs/api/tax_rates/list)
     /// - Returns: A `StripeTaxRateList`.
-    func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeTaxRateList>
+    func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeTaxRateList>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
@@ -79,7 +82,8 @@ extension TaxRateRoutes {
                        description: String? = nil,
                        jurisdiction: String? = nil,
                        metadata: [String: String]? = nil,
-                       state: String? = nil) -> EventLoopFuture<StripeTaxRate> {
+                       state: String? = nil,
+                       context: LoggingContext) -> EventLoopFuture<StripeTaxRate> {
         return create(displayName: displayName,
                       inclusive: inclusive,
                       percentage: percentage,
@@ -91,7 +95,7 @@ extension TaxRateRoutes {
                       state: state)
     }
     
-    public func retrieve(taxRate: String) -> EventLoopFuture<StripeTaxRate> {
+    public func retrieve(taxRate: String, context: LoggingContext) -> EventLoopFuture<StripeTaxRate> {
         return retrieve(taxRate: taxRate)
     }
     
@@ -102,7 +106,8 @@ extension TaxRateRoutes {
                        displayName: String? = nil,
                        jurisdiction: String? = nil,
                        metadata: [String: String]? = nil,
-                       state: String? = nil) -> EventLoopFuture<StripeTaxRate> {
+                       state: String? = nil,
+                       context: LoggingContext) -> EventLoopFuture<StripeTaxRate> {
         return update(taxRate: taxRate,
                       active: active,
                       country: country,
@@ -113,7 +118,7 @@ extension TaxRateRoutes {
                       state: state)
     }
     
-    public func listAll(filter: [String: Any]? = nil) -> EventLoopFuture<StripeTaxRateList> {
+    public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeTaxRateList> {
         return listAll(filter: filter)
     }
 }
@@ -136,7 +141,8 @@ public struct StripeTaxRateRoutes: TaxRateRoutes {
                        description: String?,
                        jurisdiction: String?,
                        metadata: [String: String]?,
-                       state: String?) -> EventLoopFuture<StripeTaxRate> {
+                       state: String?,
+                       context: LoggingContext) -> EventLoopFuture<StripeTaxRate> {
         var body: [String: Any] = ["display_name": displayName,
                                    "inclusive": inclusive,
                                    "percentage": percentage]
@@ -168,7 +174,7 @@ public struct StripeTaxRateRoutes: TaxRateRoutes {
         return apiHandler.send(method: .POST, path: taxrates, body: .string(body.queryParameters), headers: headers)
     }
     
-    public func retrieve(taxRate: String) -> EventLoopFuture<StripeTaxRate> {
+    public func retrieve(taxRate: String, context: LoggingContext) -> EventLoopFuture<StripeTaxRate> {
         return apiHandler.send(method: .GET, path: "\(taxrates)/\(taxRate)", headers: headers)
     }
     
@@ -179,7 +185,8 @@ public struct StripeTaxRateRoutes: TaxRateRoutes {
                        displayName: String?,
                        jurisdiction: String?,
                        metadata: [String: String]?,
-                       state: String?) -> EventLoopFuture<StripeTaxRate> {
+                       state: String?,
+                       context: LoggingContext) -> EventLoopFuture<StripeTaxRate> {
         var body: [String: Any] = [:]
         
         if let active = active {
@@ -213,7 +220,7 @@ public struct StripeTaxRateRoutes: TaxRateRoutes {
         return apiHandler.send(method: .POST, path: "\(taxrates)/\(taxRate)", body: .string(body.queryParameters), headers: headers)
     }
     
-    public func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeTaxRateList> {
+    public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeTaxRateList> {
         var queryParams = ""
         if let filter = filter {
             queryParams += filter.queryParameters

--- a/Sources/StripeKit/Billing/Tax Rates/TaxRateRoutes.swift
+++ b/Sources/StripeKit/Billing/Tax Rates/TaxRateRoutes.swift
@@ -92,11 +92,12 @@ extension TaxRateRoutes {
                       description: description,
                       jurisdiction: jurisdiction,
                       metadata: metadata,
-                      state: state)
+                      state: state,
+                      context: context)
     }
     
     public func retrieve(taxRate: String, context: LoggingContext) -> EventLoopFuture<StripeTaxRate> {
-        return retrieve(taxRate: taxRate)
+        return retrieve(taxRate: taxRate, context: context)
     }
     
     public func update(taxRate: String,
@@ -115,11 +116,12 @@ extension TaxRateRoutes {
                       displayName: displayName,
                       jurisdiction: jurisdiction,
                       metadata: metadata,
-                      state: state)
+                      state: state,
+                      context: context)
     }
     
     public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeTaxRateList> {
-        return listAll(filter: filter)
+        return listAll(filter: filter, context: context)
     }
 }
 
@@ -171,11 +173,11 @@ public struct StripeTaxRateRoutes: TaxRateRoutes {
             body["state"] = state
         }
         
-        return apiHandler.send(method: .POST, path: taxrates, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: taxrates, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(taxRate: String, context: LoggingContext) -> EventLoopFuture<StripeTaxRate> {
-        return apiHandler.send(method: .GET, path: "\(taxrates)/\(taxRate)", headers: headers)
+        return apiHandler.send(method: .GET, path: "\(taxrates)/\(taxRate)", headers: headers, context: context)
     }
     
     public func update(taxRate: String,
@@ -217,7 +219,7 @@ public struct StripeTaxRateRoutes: TaxRateRoutes {
             body["state"] = state
         }
         
-        return apiHandler.send(method: .POST, path: "\(taxrates)/\(taxRate)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(taxrates)/\(taxRate)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeTaxRateList> {
@@ -226,6 +228,6 @@ public struct StripeTaxRateRoutes: TaxRateRoutes {
             queryParams += filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: taxrates, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: taxrates, query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Billing/Usage records/UsageRecordRoutes.swift
+++ b/Sources/StripeKit/Billing/Usage records/UsageRecordRoutes.swift
@@ -46,11 +46,12 @@ extension UsageRecordRoutes {
         return create(quantity: quantity,
                       subscriptionItem: subscriptionItem,
                       timestamp: timestamp,
-                      action: action)
+                      action: action,
+                      context: context)
     }
     
     public func listAll(subscriptionItem: String, filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeUsageRecordList> {
-        return listAll(subscriptionItem: subscriptionItem, filter: filter)
+        return listAll(subscriptionItem: subscriptionItem, filter: filter, context: context)
     }
 }
 
@@ -76,7 +77,7 @@ public struct StripeUsageRecordRoutes: UsageRecordRoutes {
             body["action"] = action
         }
         
-        return apiHandler.send(method: .POST, path: "\(subscriptionitems)/\(subscriptionItem)/usage_records", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(subscriptionitems)/\(subscriptionItem)/usage_records", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func listAll(subscriptionItem: String, filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeUsageRecordList> {
@@ -85,6 +86,6 @@ public struct StripeUsageRecordRoutes: UsageRecordRoutes {
             queryParams += filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: "\(subscriptionitems)/\(subscriptionItem)/usage_record_summaries", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(subscriptionitems)/\(subscriptionItem)/usage_record_summaries", query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Checkout/SessionRoutes.swift
+++ b/Sources/StripeKit/Checkout/SessionRoutes.swift
@@ -7,6 +7,7 @@
 
 import NIO
 import NIOHTTP1
+import Baggage
 
 public protocol SessionRoutes {
     /// Creates a Session object.
@@ -52,7 +53,8 @@ public protocol SessionRoutes {
                 shippingRates: [String]?,
                 submitType: StripeSessionSubmitType?,
                 subscriptionData: [String: Any]?,
-                expand: [String]?) -> EventLoopFuture<StripeSession>
+                expand: [String]?,
+                context: LoggingContext) -> EventLoopFuture<StripeSession>
     
     /// Retrieves a Session object.
     ///
@@ -60,18 +62,18 @@ public protocol SessionRoutes {
     ///   - id: The ID of the Checkout Session.
     ///   - expand: An aray of properties to expand.
     /// - Returns: A `StripeSession`.
-    func retrieve(id: String, expand: [String]?) -> EventLoopFuture<StripeSession>
+    func retrieve(id: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeSession>
     
     /// Returns a list of Checkout Sessions.
     /// - Parameter filter: A dictionary that will be used for the [query parameters.](https://stripe.com/docs/api/checkout/sessions/list)
-    func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeSessionList>
+    func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeSessionList>
     
     
     /// Returns a list of ine items for a Checkout Session.
     /// - Parameters:
     ///   - session: The ID of the checkout session
     ///   - filter: A dictionary that will be used for the [query parameters.](https://stripe.com/docs/api/checkout/sessions/line_items)
-    func retrieveLineItems(session: String, filter: [String: Any]?) -> EventLoopFuture<StripeSessionLineItemList>
+    func retrieveLineItems(session: String, filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeSessionLineItemList>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
@@ -97,7 +99,8 @@ extension SessionRoutes {
                        shippingRates: [String]? = nil,
                        submitType: StripeSessionSubmitType? = nil,
                        subscriptionData: [String: Any]? = nil,
-                       expand: [String]? = nil) -> EventLoopFuture<StripeSession> {
+                       expand: [String]? = nil,
+                       context: LoggingContext) -> EventLoopFuture<StripeSession> {
         return create(cancelUrl: cancelUrl,
                       paymentMethodTypes: paymentMethodTypes,
                       successUrl: successUrl,
@@ -120,15 +123,15 @@ extension SessionRoutes {
                       expand: expand)
     }
     
-    public func retrieve(id: String, expand: [String]? = nil) -> EventLoopFuture<StripeSession> {
+    public func retrieve(id: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeSession> {
         return retrieve(id: id, expand: expand)
     }
     
-    public func listAll(filter: [String: Any]? = nil) -> EventLoopFuture<StripeSessionList> {
+    public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeSessionList> {
         listAll(filter: filter)
     }
     
-    public func retrieveLineItems(session: String, filter: [String: Any]? = nil) -> EventLoopFuture<StripeSessionLineItemList> {
+    public func retrieveLineItems(session: String, filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeSessionLineItemList> {
         retrieveLineItems(session: session, filter: filter)
     }
 }
@@ -162,7 +165,8 @@ public struct StripeSessionRoutes: SessionRoutes {
                        shippingRates: [String]?,
                        submitType: StripeSessionSubmitType?,
                        subscriptionData: [String: Any]?,
-                       expand: [String]?) -> EventLoopFuture<StripeSession> {
+                       expand: [String]?,
+                       context: LoggingContext) -> EventLoopFuture<StripeSession> {
         var body: [String: Any] = ["cancel_url": cancelUrl,
                                    "payment_method_types": paymentMethodTypes.map { $0.rawValue },
                                    "success_url": successUrl]
@@ -238,7 +242,7 @@ public struct StripeSessionRoutes: SessionRoutes {
         return apiHandler.send(method: .POST, path: sessions, body: .string(body.queryParameters), headers: headers)
     }
     
-    public func retrieve(id: String, expand: [String]?) -> EventLoopFuture<StripeSession> {
+    public func retrieve(id: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeSession> {
         var queryParams = ""
         if let expand = expand {
             queryParams = ["expand": expand].queryParameters
@@ -247,7 +251,7 @@ public struct StripeSessionRoutes: SessionRoutes {
         return apiHandler.send(method: .GET, path: "\(sessions)/\(id)", query: queryParams, headers: headers)
     }
     
-    public func listAll(filter: [String: Any]? = nil) -> EventLoopFuture<StripeSessionList> {
+    public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeSessionList> {
         var queryParams = ""
         if let filter = filter {
             queryParams = filter.queryParameters
@@ -256,7 +260,7 @@ public struct StripeSessionRoutes: SessionRoutes {
         return apiHandler.send(method: .GET, path: sessions, query: queryParams, headers: headers)
     }
     
-    public func retrieveLineItems(session: String, filter: [String: Any]?) -> EventLoopFuture<StripeSessionLineItemList> {
+    public func retrieveLineItems(session: String, filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeSessionLineItemList> {
         var queryParams = ""
         if let filter = filter {
             queryParams = filter.queryParameters

--- a/Sources/StripeKit/Checkout/SessionRoutes.swift
+++ b/Sources/StripeKit/Checkout/SessionRoutes.swift
@@ -120,19 +120,20 @@ extension SessionRoutes {
                       shippingRates: shippingRates,
                       submitType: submitType,
                       subscriptionData: subscriptionData,
-                      expand: expand)
+                      expand: expand,
+                      context: context)
     }
     
     public func retrieve(id: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeSession> {
-        return retrieve(id: id, expand: expand)
+        return retrieve(id: id, expand: expand, context: context)
     }
     
     public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeSessionList> {
-        listAll(filter: filter)
+        listAll(filter: filter, context: context)
     }
     
     public func retrieveLineItems(session: String, filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeSessionLineItemList> {
-        retrieveLineItems(session: session, filter: filter)
+        retrieveLineItems(session: session, filter: filter, context: context)
     }
 }
 
@@ -239,7 +240,7 @@ public struct StripeSessionRoutes: SessionRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: sessions, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: sessions, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(id: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeSession> {
@@ -248,7 +249,7 @@ public struct StripeSessionRoutes: SessionRoutes {
             queryParams = ["expand": expand].queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: "\(sessions)/\(id)", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(sessions)/\(id)", query: queryParams, headers: headers, context: context)
     }
     
     public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeSessionList> {
@@ -257,7 +258,7 @@ public struct StripeSessionRoutes: SessionRoutes {
             queryParams = filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: sessions, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: sessions, query: queryParams, headers: headers, context: context)
     }
     
     public func retrieveLineItems(session: String, filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeSessionLineItemList> {
@@ -266,6 +267,6 @@ public struct StripeSessionRoutes: SessionRoutes {
             queryParams = filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: "\(sessions)/\(session)/line_items", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(sessions)/\(session)/line_items", query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Connect/Account Links/AccountLinkRoutes.swift
+++ b/Sources/StripeKit/Connect/Account Links/AccountLinkRoutes.swift
@@ -8,6 +8,7 @@
 import NIO
 import NIOHTTP1
 import Foundation
+import Baggage
 
 public protocol AccountLinkRoutes {
     
@@ -22,7 +23,8 @@ public protocol AccountLinkRoutes {
                 refreshUrl: String,
                 returnUrl: String,
                 type: AccountLinkCreationType,
-                collect: AccountLinkCreationCollectType?) -> EventLoopFuture<AccountLink>
+                collect: AccountLinkCreationCollectType?,
+                context: LoggingContext) -> EventLoopFuture<AccountLink>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
@@ -42,7 +44,8 @@ public struct StripeAccountLinkRoutes: AccountLinkRoutes {
                        refreshUrl: String,
                        returnUrl: String,
                        type: AccountLinkCreationType,
-                       collect: AccountLinkCreationCollectType?) -> EventLoopFuture<AccountLink> {
+                       collect: AccountLinkCreationCollectType?,
+                       context: LoggingContext) -> EventLoopFuture<AccountLink> {
         var body: [String: Any] = ["account": account,
                                    "refresh_url": refreshUrl,
                                    "success_url": returnUrl,

--- a/Sources/StripeKit/Connect/Account Links/AccountLinkRoutes.swift
+++ b/Sources/StripeKit/Connect/Account Links/AccountLinkRoutes.swift
@@ -55,6 +55,6 @@ public struct StripeAccountLinkRoutes: AccountLinkRoutes {
             body["collect"] = collect.rawValue
         }
         
-        return apiHandler.send(method: .POST, path: accountlinks, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: accountlinks, body: .string(body.queryParameters), headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Connect/Accounts/AccountRoutes.swift
+++ b/Sources/StripeKit/Connect/Accounts/AccountRoutes.swift
@@ -157,11 +157,12 @@ extension AccountRoutes {
                       metadata: metadata,
                       capabilities: capabilities,
                       settings: settings,
-                      tosAcceptance: tosAcceptance)
+                      tosAcceptance: tosAcceptance,
+                      context: context)
     }
     
     public func retrieve(account: String, context: LoggingContext) -> EventLoopFuture<StripeConnectAccount> {
-        return retrieve(account: account)
+        return retrieve(account: account, context: context)
     }
     
     public func update(account: String,
@@ -192,23 +193,24 @@ extension AccountRoutes {
                       metadata: metadata,
                       capabilities: capabilities,
                       settings: settings,
-                      tosAcceptance: tosAcceptance)
+                      tosAcceptance: tosAcceptance,
+                      context: context)
     }
     
     public func delete(account: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
-        return delete(account: account)
+        return delete(account: account, context: context)
     }
     
     public func reject(account: String, reason: StripeConnectAccountRejectReason, context: LoggingContext) -> EventLoopFuture<StripeConnectAccount> {
-        return reject(account: account, reason: reason)
+        return reject(account: account, reason: reason, context: context)
     }
     
     public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeConnectAccountList> {
-        return listAll(filter: filter)
+        return listAll(filter: filter, context: context)
     }
     
     public func createLoginLink(account: String, redirectUrl: String?, context: LoggingContext) -> EventLoopFuture<StripeConnectAccountLoginLink> {
-        return createLoginLink(account: account, redirectUrl: redirectUrl)
+        return createLoginLink(account: account, redirectUrl: redirectUrl, context: context)
     }
 }
 
@@ -296,11 +298,11 @@ public struct StripeConnectAccountRoutes: AccountRoutes {
             tos.forEach { body["tos_acceptance[\($0)]"] = $1 }
         }
         
-        return apiHandler.send(method: .POST, path: accounts, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: accounts, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(account: String, context: LoggingContext) -> EventLoopFuture<StripeConnectAccount> {
-        return apiHandler.send(method: .GET, path: "\(accounts)/\(account)", headers: headers)
+        return apiHandler.send(method: .GET, path: "\(accounts)/\(account)", headers: headers, context: context)
     }
     
     public func update(account: String,
@@ -374,16 +376,16 @@ public struct StripeConnectAccountRoutes: AccountRoutes {
             tos.forEach { body["tos_acceptance[\($0)]"] = $1 }
         }
         
-        return apiHandler.send(method: .POST, path: "\(accounts)/\(account)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(accounts)/\(account)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func delete(account: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
-        return apiHandler.send(method: .DELETE, path: "\(accounts)/\(account)", headers: headers)
+        return apiHandler.send(method: .DELETE, path: "\(accounts)/\(account)", headers: headers, context: context)
     }
     
     public func reject(account: String, reason: StripeConnectAccountRejectReason, context: LoggingContext) -> EventLoopFuture<StripeConnectAccount> {
         let body = ["reason": reason.rawValue]
-        return apiHandler.send(method: .POST, path: "\(accounts)/\(account)/reject", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(accounts)/\(account)/reject", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeConnectAccountList> {
@@ -391,7 +393,7 @@ public struct StripeConnectAccountRoutes: AccountRoutes {
         if let filter = filter {
             queryParams = filter.queryParameters
         }
-        return apiHandler.send(method: .GET, path: accounts, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: accounts, query: queryParams, headers: headers, context: context)
     }
     
     public func createLoginLink(account: String, redirectUrl: String?, context: LoggingContext) -> EventLoopFuture<StripeConnectAccountLoginLink> {
@@ -401,6 +403,6 @@ public struct StripeConnectAccountRoutes: AccountRoutes {
             body["redirect_url"] = redirectUrl
         }
         
-        return apiHandler.send(method: .POST, path: "\(accounts)/\(account)/login_links")
+        return apiHandler.send(method: .POST, path: "\(accounts)/\(account)/login_links", context: context)
     }
 }

--- a/Sources/StripeKit/Connect/Application Fee Refunds/ApplicationFeeRefundRoutes.swift
+++ b/Sources/StripeKit/Connect/Application Fee Refunds/ApplicationFeeRefundRoutes.swift
@@ -71,11 +71,12 @@ extension ApplicationFeeRefundRoutes {
         return create(fee: fee,
                       amount: amount,
                       metadata: metadata,
-                      expand: expand)
+                      expand: expand,
+                      context: context)
     }
     
     public func retrieve(refund: String, fee: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeApplicationFeeRefund> {
-        return retrieve(refund: refund, fee: fee, expand: expand)
+        return retrieve(refund: refund, fee: fee, expand: expand, context: context)
     }
     
     public func update(refund: String,
@@ -86,11 +87,12 @@ extension ApplicationFeeRefundRoutes {
         return update(refund: refund,
                       fee: fee,
                       metadata: metadata,
-                      expand: expand)
+                      expand: expand,
+                      context: context)
     }
     
     public func listAll(fee: String, filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeApplicationFeeRefundList> {
-        return listAll(fee: fee, filter: filter)
+        return listAll(fee: fee, filter: filter, context: context)
     }
 }
 
@@ -123,7 +125,7 @@ public struct StripeApplicationFeeRefundRoutes: ApplicationFeeRefundRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(applicationfeesrefund)/\(fee)/refunds", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(applicationfeesrefund)/\(fee)/refunds", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(refund: String, fee: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeApplicationFeeRefund> {
@@ -131,7 +133,7 @@ public struct StripeApplicationFeeRefundRoutes: ApplicationFeeRefundRoutes {
         if let expand = expand {
             queryParams = ["expand": expand].queryParameters
         }
-        return apiHandler.send(method: .GET, path: "\(applicationfeesrefund)/\(fee)/refunds/\(refund)", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(applicationfeesrefund)/\(fee)/refunds/\(refund)", query: queryParams, headers: headers, context: context)
     }
     
     public func update(refund: String,
@@ -149,7 +151,7 @@ public struct StripeApplicationFeeRefundRoutes: ApplicationFeeRefundRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(applicationfeesrefund)/\(fee)/refunds/\(refund)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(applicationfeesrefund)/\(fee)/refunds/\(refund)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func listAll(fee: String, filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeApplicationFeeList> {
@@ -157,6 +159,6 @@ public struct StripeApplicationFeeRefundRoutes: ApplicationFeeRefundRoutes {
         if let filter = filter {
             queryParams = filter.queryParameters
         }
-        return apiHandler.send(method: .GET, path: "\(applicationfeesrefund)/\(fee)/refunds", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(applicationfeesrefund)/\(fee)/refunds", query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Connect/Application Fee Refunds/ApplicationFeeRefundRoutes.swift
+++ b/Sources/StripeKit/Connect/Application Fee Refunds/ApplicationFeeRefundRoutes.swift
@@ -7,6 +7,7 @@
 
 import NIO
 import NIOHTTP1
+import Baggage
 
 public protocol ApplicationFeeRefundRoutes {
     /// Refunds an application fee that has previously been collected but not yet refunded. Funds will be refunded to the Stripe account from which the fee was originally collected.
@@ -22,7 +23,8 @@ public protocol ApplicationFeeRefundRoutes {
     func create(fee: String,
                 amount: Int?,
                 metadata: [String: String]?,
-                expand: [String]?) -> EventLoopFuture<StripeApplicationFeeRefund>
+                expand: [String]?,
+                context: LoggingContext) -> EventLoopFuture<StripeApplicationFeeRefund>
     
     /// By default, you can see the 10 most recent refunds stored directly on the application fee object, but you can also retrieve details about a specific refund stored on the application fee.
     ///
@@ -31,7 +33,7 @@ public protocol ApplicationFeeRefundRoutes {
     ///   - fee: ID of the application fee refunded.
     ///   - expand: An array of properties to expand.
     /// - Returns: A `StripeApplicationFeeRefund`.
-    func retrieve(refund: String, fee: String, expand: [String]?) -> EventLoopFuture<StripeApplicationFeeRefund>
+    func retrieve(refund: String, fee: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeApplicationFeeRefund>
     
     /// Updates the specified application fee refund by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
     /// This request only accepts metadata as an argument.
@@ -45,7 +47,8 @@ public protocol ApplicationFeeRefundRoutes {
     func update(refund: String,
                 fee: String,
                 metadata: [String: String]?,
-                expand: [String]?) -> EventLoopFuture<StripeApplicationFeeRefund>
+                expand: [String]?,
+                context: LoggingContext) -> EventLoopFuture<StripeApplicationFeeRefund>
     
     /// You can see a list of the refunds belonging to a specific application fee. Note that the 10 most recent refunds are always available by default on the application fee object. If you need more than those 10, you can use this API method and the limit and starting_after parameters to page through additional refunds.
     ///
@@ -53,7 +56,7 @@ public protocol ApplicationFeeRefundRoutes {
     ///   - fee: The ID of the application fee whose refunds will be retrieved.
     ///   - filter: A dictionary that will be used for the query parameters. [See More →](https://stripe.com/docs/api/fee_refunds/list)
     /// - Returns: A `StripeApplicationFeeRefundList`.
-    func listAll(fee: String, filter: [String: Any]?) -> EventLoopFuture<StripeApplicationFeeRefundList>
+    func listAll(fee: String, filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeApplicationFeeRefundList>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
@@ -63,28 +66,30 @@ extension ApplicationFeeRefundRoutes {
     public func create(fee: String,
                        amount: Int? = nil,
                        metadata: [String: String]? = nil,
-                       expand: [String]? = nil) -> EventLoopFuture<StripeApplicationFeeRefund> {
+                       expand: [String]? = nil,
+                       context: LoggingContext) -> EventLoopFuture<StripeApplicationFeeRefund> {
         return create(fee: fee,
                       amount: amount,
                       metadata: metadata,
                       expand: expand)
     }
     
-    public func retrieve(refund: String, fee: String, expand: [String]? = nil) -> EventLoopFuture<StripeApplicationFeeRefund> {
+    public func retrieve(refund: String, fee: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeApplicationFeeRefund> {
         return retrieve(refund: refund, fee: fee, expand: expand)
     }
     
     public func update(refund: String,
                        fee: String,
                        metadata: [String: String]? = nil,
-                       expand: [String]? = nil) -> EventLoopFuture<StripeApplicationFeeRefund> {
+                       expand: [String]? = nil,
+                       context: LoggingContext) -> EventLoopFuture<StripeApplicationFeeRefund> {
         return update(refund: refund,
                       fee: fee,
                       metadata: metadata,
                       expand: expand)
     }
     
-    public func listAll(fee: String, filter: [String: Any]? = nil) -> EventLoopFuture<StripeApplicationFeeRefundList> {
+    public func listAll(fee: String, filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeApplicationFeeRefundList> {
         return listAll(fee: fee, filter: filter)
     }
 }
@@ -102,7 +107,8 @@ public struct StripeApplicationFeeRefundRoutes: ApplicationFeeRefundRoutes {
     public func create(fee: String,
                        amount: Int?,
                        metadata: [String: String]?,
-                       expand: [String]?) -> EventLoopFuture<StripeApplicationFeeRefund> {
+                       expand: [String]?,
+                       context: LoggingContext) -> EventLoopFuture<StripeApplicationFeeRefund> {
         var body: [String: Any] = [:]
         
         if let amount = amount {
@@ -120,7 +126,7 @@ public struct StripeApplicationFeeRefundRoutes: ApplicationFeeRefundRoutes {
         return apiHandler.send(method: .POST, path: "\(applicationfeesrefund)/\(fee)/refunds", body: .string(body.queryParameters), headers: headers)
     }
     
-    public func retrieve(refund: String, fee: String, expand: [String]?) -> EventLoopFuture<StripeApplicationFeeRefund> {
+    public func retrieve(refund: String, fee: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeApplicationFeeRefund> {
         var queryParams = ""
         if let expand = expand {
             queryParams = ["expand": expand].queryParameters
@@ -131,7 +137,8 @@ public struct StripeApplicationFeeRefundRoutes: ApplicationFeeRefundRoutes {
     public func update(refund: String,
                        fee: String,
                        metadata: [String: String]?,
-                       expand: [String]?) -> EventLoopFuture<StripeApplicationFeeRefund> {
+                       expand: [String]?,
+                       context: LoggingContext) -> EventLoopFuture<StripeApplicationFeeRefund> {
         var body: [String: Any] = [:]
         
         if let metadata = metadata {
@@ -145,7 +152,7 @@ public struct StripeApplicationFeeRefundRoutes: ApplicationFeeRefundRoutes {
         return apiHandler.send(method: .POST, path: "\(applicationfeesrefund)/\(fee)/refunds/\(refund)", body: .string(body.queryParameters), headers: headers)
     }
     
-    public func listAll(fee: String, filter: [String: Any]?) -> EventLoopFuture<StripeApplicationFeeList> {
+    public func listAll(fee: String, filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeApplicationFeeList> {
         var queryParams = ""
         if let filter = filter {
             queryParams = filter.queryParameters

--- a/Sources/StripeKit/Connect/Application Fees/ApplicationFeesRoutes.swift
+++ b/Sources/StripeKit/Connect/Application Fees/ApplicationFeesRoutes.swift
@@ -30,11 +30,11 @@ public protocol ApplicationFeesRoutes {
 
 extension ApplicationFeesRoutes {
     public func retrieve(fee: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeApplicationFee> {
-        return retrieve(fee: fee, expand: expand)
+        return retrieve(fee: fee, expand: expand, context: context)
     }
     
     public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeApplicationFeeList> {
-        return listAll(filter: filter)
+        return listAll(filter: filter, context: context)
     }
 }
 
@@ -53,7 +53,7 @@ public struct StripeApplicationFeeRoutes: ApplicationFeesRoutes {
         if let expand = expand {
             queryParams = ["expand": expand].queryParameters
         }
-        return apiHandler.send(method: .GET, path: "\(applicationfees)/\(fee)", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(applicationfees)/\(fee)", query: queryParams, headers: headers, context: context)
     }
     
     public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeApplicationFeeList> {
@@ -61,6 +61,6 @@ public struct StripeApplicationFeeRoutes: ApplicationFeesRoutes {
         if let filter = filter {
             queryParams = filter.queryParameters
         }
-        return apiHandler.send(method: .GET, path: applicationfees, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: applicationfees, query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Connect/Application Fees/ApplicationFeesRoutes.swift
+++ b/Sources/StripeKit/Connect/Application Fees/ApplicationFeesRoutes.swift
@@ -7,6 +7,7 @@
 
 import NIO
 import NIOHTTP1
+import Baggage
 
 public protocol ApplicationFeesRoutes {
     /// Retrieves the details of an application fee that your account has collected. The same information is returned when refunding the application fee.
@@ -15,24 +16,24 @@ public protocol ApplicationFeesRoutes {
     ///   - fee: The identifier of the fee to be retrieved.
     ///   - expand: An array of properties to expand.
     /// - Returns: A `StripeApplicationFee`.
-    func retrieve(fee: String, expand: [String]?) -> EventLoopFuture<StripeApplicationFee>
+    func retrieve(fee: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeApplicationFee>
     
     /// Returns a list of application fees you’ve previously collected. The application fees are returned in sorted order, with the most recent fees appearing first.
     ///
     /// - Parameter filter: A dictionary that will be used for the query parameters. [See More →](https://stripe.com/docs/api/application_fees/list)
     /// - Returns: A `StripeApplicationFeeList`.
-    func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeApplicationFeeList>
+    func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeApplicationFeeList>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
 }
 
 extension ApplicationFeesRoutes {
-    public func retrieve(fee: String, expand: [String]? = nil) -> EventLoopFuture<StripeApplicationFee> {
+    public func retrieve(fee: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeApplicationFee> {
         return retrieve(fee: fee, expand: expand)
     }
     
-    public func listAll(filter: [String: Any]? = nil) -> EventLoopFuture<StripeApplicationFeeList> {
+    public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeApplicationFeeList> {
         return listAll(filter: filter)
     }
 }
@@ -47,7 +48,7 @@ public struct StripeApplicationFeeRoutes: ApplicationFeesRoutes {
         self.apiHandler = apiHandler
     }
     
-    public func retrieve(fee: String, expand: [String]?) -> EventLoopFuture<StripeApplicationFee> {
+    public func retrieve(fee: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeApplicationFee> {
         var queryParams = ""
         if let expand = expand {
             queryParams = ["expand": expand].queryParameters
@@ -55,7 +56,7 @@ public struct StripeApplicationFeeRoutes: ApplicationFeesRoutes {
         return apiHandler.send(method: .GET, path: "\(applicationfees)/\(fee)", query: queryParams, headers: headers)
     }
     
-    public func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeApplicationFeeList> {
+    public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeApplicationFeeList> {
         var queryParams = ""
         if let filter = filter {
             queryParams = filter.queryParameters

--- a/Sources/StripeKit/Connect/Capabilities/CapabiliitiesRoutes.swift
+++ b/Sources/StripeKit/Connect/Capabilities/CapabiliitiesRoutes.swift
@@ -33,15 +33,15 @@ public protocol CapabilitiesRoutes {
 
 extension CapabilitiesRoutes {
     public func retrieve(capability: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeCapability> {
-        return retrieve(capability: capability, expand: expand)
+        return retrieve(capability: capability, expand: expand, context: context)
     }
     
     public func update(capability: String, requested: Bool? = nil, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeCapability> {
-        return update(capability: capability, requested: requested, expand: expand)
+        return update(capability: capability, requested: requested, expand: expand, context: context)
     }
     
     public func listAll(account: String, context: LoggingContext) -> EventLoopFuture<StripeCapabilitiesList> {
-        return listAll(account: account)
+        return listAll(account: account, context: context)
     }
 }
 
@@ -62,7 +62,7 @@ public struct StripeCapabilitiesRoutes: CapabilitiesRoutes {
             queryParams += ["expand": expand].queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: "\(capabilities)/\(capability)/capabilities/card_payments", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(capabilities)/\(capability)/capabilities/card_payments", query: queryParams, headers: headers, context: context)
     }
     
     public func update(capability: String, requested: Bool?, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeCapability> {
@@ -76,10 +76,10 @@ public struct StripeCapabilitiesRoutes: CapabilitiesRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(capabilities)/\(capability)/capabilities/card_payments", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(capabilities)/\(capability)/capabilities/card_payments", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func listAll(account: String, context: LoggingContext) -> EventLoopFuture<StripeCapabilitiesList> {
-        return apiHandler.send(method: .GET, path: "\(capabilities)/\(account)/capabilities", headers: headers)
+        return apiHandler.send(method: .GET, path: "\(capabilities)/\(account)/capabilities", headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Connect/Capabilities/CapabiliitiesRoutes.swift
+++ b/Sources/StripeKit/Connect/Capabilities/CapabiliitiesRoutes.swift
@@ -7,6 +7,7 @@
 
 import NIO
 import NIOHTTP1
+import Baggage
 
 public protocol CapabilitiesRoutes {
     
@@ -14,32 +15,32 @@ public protocol CapabilitiesRoutes {
     /// - Parameters:
     ///   - capability: The ID of an account capability to retrieve.
     ///   - expand: An array of properties to expand.
-    func retrieve(capability: String, expand: [String]?) -> EventLoopFuture<StripeCapability>
+    func retrieve(capability: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeCapability>
     
     /// Updates an existing Account Capability.
     /// - Parameter capability: The ID of an account capability to update.
     /// - Parameter requested: Passing true requests the capability for the account, if it is not already requested. A requested capability may not immediately become active. Any requirements to activate the capability are returned in the `requirements` arrays.
     /// - Parameter expand: An array of properties to expand.
-    func update(capability: String, requested: Bool?, expand: [String]?) -> EventLoopFuture<StripeCapability>
+    func update(capability: String, requested: Bool?, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeCapability>
     
     /// Returns a list of capabilities associated with the account. The capabilities are returned sorted by creation date, with the most recent capability appearing first.
     /// - Parameter account: The ID of the connect account.
-    func listAll(account: String) -> EventLoopFuture<StripeCapabilitiesList>
+    func listAll(account: String, context: LoggingContext) -> EventLoopFuture<StripeCapabilitiesList>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
 }
 
 extension CapabilitiesRoutes {
-    public func retrieve(capability: String, expand: [String]?) -> EventLoopFuture<StripeCapability> {
+    public func retrieve(capability: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeCapability> {
         return retrieve(capability: capability, expand: expand)
     }
     
-    public func update(capability: String, requested: Bool? = nil, expand: [String]? = nil) -> EventLoopFuture<StripeCapability> {
+    public func update(capability: String, requested: Bool? = nil, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeCapability> {
         return update(capability: capability, requested: requested, expand: expand)
     }
     
-    public func listAll(account: String) -> EventLoopFuture<StripeCapabilitiesList> {
+    public func listAll(account: String, context: LoggingContext) -> EventLoopFuture<StripeCapabilitiesList> {
         return listAll(account: account)
     }
 }
@@ -54,7 +55,7 @@ public struct StripeCapabilitiesRoutes: CapabilitiesRoutes {
         self.apiHandler = apiHandler
     }
 
-    public func retrieve(capability: String, expand: [String]?) -> EventLoopFuture<StripeCapability> {
+    public func retrieve(capability: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeCapability> {
         var queryParams = ""
         
         if let expand = expand {
@@ -64,7 +65,7 @@ public struct StripeCapabilitiesRoutes: CapabilitiesRoutes {
         return apiHandler.send(method: .GET, path: "\(capabilities)/\(capability)/capabilities/card_payments", query: queryParams, headers: headers)
     }
     
-    public func update(capability: String, requested: Bool?, expand: [String]?) -> EventLoopFuture<StripeCapability> {
+    public func update(capability: String, requested: Bool?, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeCapability> {
         var body: [String: Any] = [:]
         
         if let requested = requested {
@@ -78,7 +79,7 @@ public struct StripeCapabilitiesRoutes: CapabilitiesRoutes {
         return apiHandler.send(method: .POST, path: "\(capabilities)/\(capability)/capabilities/card_payments", body: .string(body.queryParameters), headers: headers)
     }
     
-    public func listAll(account: String) -> EventLoopFuture<StripeCapabilitiesList> {
+    public func listAll(account: String, context: LoggingContext) -> EventLoopFuture<StripeCapabilitiesList> {
         return apiHandler.send(method: .GET, path: "\(capabilities)/\(account)/capabilities", headers: headers)
     }
 }

--- a/Sources/StripeKit/Connect/Country Specs/CountrySpecRoutes.swift
+++ b/Sources/StripeKit/Connect/Country Specs/CountrySpecRoutes.swift
@@ -28,11 +28,11 @@ public protocol CountrySpecRoutes {
 
 extension CountrySpecRoutes {
     public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeCountrySpecList> {
-        return listAll(filter: filter)
+        return listAll(filter: filter, context: context)
     }
     
     public func retrieve(country: String, context: LoggingContext) -> EventLoopFuture<StripeCountrySpec> {
-        return retrieve(country: country)
+        return retrieve(country: country, context: context)
     }
 }
 
@@ -51,10 +51,10 @@ public struct StripeCountrySpecRoutes: CountrySpecRoutes {
         if let filter = filter {
             queryParams = filter.queryParameters
         }
-        return apiHandler.send(method: .GET, path: countryspecs, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: countryspecs, query: queryParams, headers: headers, context: context)
     }
     
     public func retrieve(country: String, context: LoggingContext) -> EventLoopFuture<StripeCountrySpec> {
-         return apiHandler.send(method: .GET, path: "\(countryspecs)/\(country)", headers: headers)
+         return apiHandler.send(method: .GET, path: "\(countryspecs)/\(country)", headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Connect/Country Specs/CountrySpecRoutes.swift
+++ b/Sources/StripeKit/Connect/Country Specs/CountrySpecRoutes.swift
@@ -7,30 +7,31 @@
 
 import NIO
 import NIOHTTP1
+import Baggage
 
 public protocol CountrySpecRoutes {
     /// Lists all Country Spec objects available in the API.
     ///
     /// - Parameter filter: A dictionary that will be used for the query parameters. [See More →](https://stripe.com/docs/api/country_specs/list)
     /// - Returns: A `StripeCountrySpecList`.
-    func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeCountrySpecList>
+    func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeCountrySpecList>
     
     /// Returns a Country Spec for a given Country code.
     ///
     /// - Parameter country: An ISO 3166-1 alpha-2 country code. Available country codes can be listed with the [List Country Specs](https://stripe.com/docs/api#list_country_specs) endpoint.
     /// - Returns: A `StripeCountrySpec`.
-    func retrieve(country: String) -> EventLoopFuture<StripeCountrySpec>
+    func retrieve(country: String, context: LoggingContext) -> EventLoopFuture<StripeCountrySpec>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
 }
 
 extension CountrySpecRoutes {
-    public func listAll(filter: [String: Any]? = nil) -> EventLoopFuture<StripeCountrySpecList> {
+    public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeCountrySpecList> {
         return listAll(filter: filter)
     }
     
-    public func retrieve(country: String) -> EventLoopFuture<StripeCountrySpec> {
+    public func retrieve(country: String, context: LoggingContext) -> EventLoopFuture<StripeCountrySpec> {
         return retrieve(country: country)
     }
 }
@@ -45,7 +46,7 @@ public struct StripeCountrySpecRoutes: CountrySpecRoutes {
         self.apiHandler = apiHandler
     }
     
-    public func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeCountrySpecList> {
+    public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeCountrySpecList> {
         var queryParams = ""
         if let filter = filter {
             queryParams = filter.queryParameters
@@ -53,7 +54,7 @@ public struct StripeCountrySpecRoutes: CountrySpecRoutes {
         return apiHandler.send(method: .GET, path: countryspecs, query: queryParams, headers: headers)
     }
     
-    public func retrieve(country: String) -> EventLoopFuture<StripeCountrySpec> {
+    public func retrieve(country: String, context: LoggingContext) -> EventLoopFuture<StripeCountrySpec> {
          return apiHandler.send(method: .GET, path: "\(countryspecs)/\(country)", headers: headers)
     }
 }

--- a/Sources/StripeKit/Connect/External Accounts/ExternalAccountsRoutes.swift
+++ b/Sources/StripeKit/Connect/External Accounts/ExternalAccountsRoutes.swift
@@ -136,11 +136,11 @@ public protocol ExternalAccountsRoutes {
 
 extension ExternalAccountsRoutes {
     public func create(account: String, bankAccount: Any, defaultForCurrency: Bool? = nil, metadata: [String: String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeBankAccount> {
-        return create(account: account, bankAccount: bankAccount, defaultForCurrency: defaultForCurrency, metadata: metadata)
+        return create(account: account, bankAccount: bankAccount, defaultForCurrency: defaultForCurrency, metadata: metadata, context: context)
     }
     
     public func retrieve(account: String, id: String, context: LoggingContext) -> EventLoopFuture<StripeBankAccount> {
-        return retrieve(account: account, id: id)
+        return retrieve(account: account, id: id, context: context)
     }
     
     public func update(account: String,
@@ -151,27 +151,28 @@ extension ExternalAccountsRoutes {
                        metadata: [String: String]? = nil,
                        context: LoggingContext) -> EventLoopFuture<StripeBankAccount> {
         return update(account: account,
-                          id: id,
-                          accountHolderName: accountHolderName,
-                          accountHolderType: accountHolderType,
-                          defaultForCurrency: defaultForCurrency,
-                          metadata: metadata)
+                      id: id,
+                      accountHolderName: accountHolderName,
+                      accountHolderType: accountHolderType,
+                      defaultForCurrency: defaultForCurrency,
+                      metadata: metadata,
+                      context: context)
     }
     
     public func deleteBankAccount(account: String, id: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
-        return deleteBankAccount(account: account, id: id)
+        return deleteBankAccount(account: account, id: id, context: context)
     }
     
     public func listAll(account: String, filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeBankAccountList> {
-        return listAll(account: account, filter: filter)
+        return listAll(account: account, filter: filter, context: context)
     }
     
     public func create(account: String, card: Any, defaultForCurrency: Bool? = nil, metadata: [String: String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeCard> {
-        return create(account: account, card: card, defaultForCurrency: defaultForCurrency, metadata: metadata)
+        return create(account: account, card: card, defaultForCurrency: defaultForCurrency, metadata: metadata, context: context)
     }
     
     public func retrieve(account: String, id: String, context: LoggingContext) -> EventLoopFuture<StripeCard> {
-        return retrieve(account: account, id: id)
+        return retrieve(account: account, id: id, context: context)
     }
     
     public func update(account: String,
@@ -189,26 +190,27 @@ extension ExternalAccountsRoutes {
                        name: String?,
                        context: LoggingContext) -> EventLoopFuture<StripeCard> {
         return update(account: account,
-                          id: id,
-                          addressCity: addressCity,
-                          addressCountry: addressCountry,
-                          addressLine1: addressLine1,
-                          addressLine2: addressLine2,
-                          addressState: addressState,
-                          addressZip: addressZip,
-                          defaultForCurrency: defaultForCurrency,
-                          expMonth: expMonth,
-                          expYear: expYear,
-                          metadata: metadata,
-                          name: name)
+                      id: id,
+                      addressCity: addressCity,
+                      addressCountry: addressCountry,
+                      addressLine1: addressLine1,
+                      addressLine2: addressLine2,
+                      addressState: addressState,
+                      addressZip: addressZip,
+                      defaultForCurrency: defaultForCurrency,
+                      expMonth: expMonth,
+                      expYear: expYear,
+                      metadata: metadata,
+                      name: name,
+                      context: context)
     }
     
     public func deleteCard(account: String, id: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
-        return deleteCard(account: account, id: id)
+        return deleteCard(account: account, id: id, context: context)
     }
     
     public func listAll(account: String, filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeCardList> {
-        return listAll(account: account, filter: filter)
+        return listAll(account: account, filter: filter, context: context)
     }
 }
 
@@ -239,11 +241,11 @@ public struct StripeExternalAccountsRoutes: ExternalAccountsRoutes {
             metadata.forEach { body["metadata[\($0)]"] = $1 }
         }
         
-        return apiHandler.send(method: .POST, path: "\(accounts)/\(account)/external_accounts", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(accounts)/\(account)/external_accounts", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(account: String, id: String, context: LoggingContext) -> EventLoopFuture<StripeBankAccount> {
-        return apiHandler.send(method: .GET, path: "\(accounts)/\(account)/external_accounts/\(id)", headers: headers)
+        return apiHandler.send(method: .GET, path: "\(accounts)/\(account)/external_accounts/\(id)", headers: headers, context: context)
     }
     
     public func update(account: String,
@@ -271,11 +273,11 @@ public struct StripeExternalAccountsRoutes: ExternalAccountsRoutes {
             metadata.forEach { body["metadata[\($0)]"] = $1 }
         }
         
-        return apiHandler.send(method: .POST, path: "\(accounts)/\(account)/external_accounts/\(id)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(accounts)/\(account)/external_accounts/\(id)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func deleteBankAccount(account: String, id: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
-        return apiHandler.send(method: .DELETE, path: "\(accounts)/\(account)/external_accounts/\(id)", headers: headers)
+        return apiHandler.send(method: .DELETE, path: "\(accounts)/\(account)/external_accounts/\(id)", headers: headers, context: context)
     }
     
     public func listAll(account: String, filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeBankAccountList> {
@@ -283,7 +285,7 @@ public struct StripeExternalAccountsRoutes: ExternalAccountsRoutes {
         if let filter = filter {
             queryParams = filter.queryParameters
         }
-        return apiHandler.send(method: .GET, path: "\(accounts)/\(account)/external_accounts", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(accounts)/\(account)/external_accounts", query: queryParams, headers: headers, context: context)
     }
     
     public func create(account: String, card: Any, defaultForCurrency: Bool?, metadata: [String: String]?, context: LoggingContext) -> EventLoopFuture<StripeCard> {
@@ -303,11 +305,11 @@ public struct StripeExternalAccountsRoutes: ExternalAccountsRoutes {
             metadata.forEach { body["metadata[\($0)]"] = $1 }
         }
         
-        return apiHandler.send(method: .POST, path: "\(accounts)/\(account)/external_accounts", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(accounts)/\(account)/external_accounts", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(account: String, id: String, context: LoggingContext) -> EventLoopFuture<StripeCard> {
-        return apiHandler.send(method: .GET, path: "\(accounts)/\(account)/external_accounts/\(id)", headers: headers)
+        return apiHandler.send(method: .GET, path: "\(accounts)/\(account)/external_accounts/\(id)", headers: headers, context: context)
     }
     
     public func update(account: String,
@@ -370,11 +372,11 @@ public struct StripeExternalAccountsRoutes: ExternalAccountsRoutes {
             body["name"] = name
         }
         
-        return apiHandler.send(method: .POST, path: "\(accounts)/\(account)/external_accounts/\(id)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(accounts)/\(account)/external_accounts/\(id)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func deleteCard(account: String, id: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
-        return apiHandler.send(method: .DELETE, path: "\(accounts)/\(account)/external_accounts/\(id)", headers: headers)
+        return apiHandler.send(method: .DELETE, path: "\(accounts)/\(account)/external_accounts/\(id)", headers: headers, context: context)
     }
     
     public func listAll(account: String, filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeCardList> {
@@ -382,6 +384,6 @@ public struct StripeExternalAccountsRoutes: ExternalAccountsRoutes {
         if let filter = filter {
             queryParams = filter.queryParameters
         }
-        return apiHandler.send(method: .GET, path: "\(accounts)/\(account)/external_accounts", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(accounts)/\(account)/external_accounts", query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Connect/External Accounts/ExternalAccountsRoutes.swift
+++ b/Sources/StripeKit/Connect/External Accounts/ExternalAccountsRoutes.swift
@@ -7,6 +7,7 @@
 
 import NIO
 import NIOHTTP1
+import Baggage
 
 public protocol ExternalAccountsRoutes {
     /// Creates a new bank account. When you create a new bank account, you must specify a [Custom account](https://stripe.com/docs/connect/custom-accounts) to create it on.
@@ -18,7 +19,7 @@ public protocol ExternalAccountsRoutes {
 
     ///   - metadata: A set of key-value pairs that you can attach to an external account object. It can be useful for storing additional information about the external account in a structured format.
     /// - Returns: A `StripeBankAccount`.
-    func create(account: String, bankAccount: Any, defaultForCurrency: Bool?, metadata: [String: String]?) -> EventLoopFuture<StripeBankAccount>
+    func create(account: String, bankAccount: Any, defaultForCurrency: Bool?, metadata: [String: String]?, context: LoggingContext) -> EventLoopFuture<StripeBankAccount>
     
     /// By default, you can see the 10 most recent external accounts stored on a Custom account directly on the object, but you can also retrieve details about a specific bank account stored on the [Custom account](https://stripe.com/docs/connect/custom-accounts).
     ///
@@ -26,7 +27,7 @@ public protocol ExternalAccountsRoutes {
     ///   - account: The connect account associated with this bank account.
     ///   - id: The ID of the bank account to retrieve.
     /// - Returns: A `StripeBankAccount`.
-    func retrieve(account: String, id: String) -> EventLoopFuture<StripeBankAccount>
+    func retrieve(account: String, id: String, context: LoggingContext) -> EventLoopFuture<StripeBankAccount>
     
     /// Updates the metadata, account holder name, and account holder type of a bank account belonging to a [Custom account](https://stripe.com/docs/connect/custom-accounts), and optionally sets it as the default for its currency. Other bank account details are not editable by design. \n You can re-enable a disabled bank account by performing an update call without providing any arguments or changes.
     ///
@@ -43,7 +44,8 @@ public protocol ExternalAccountsRoutes {
                 accountHolderName: String?,
                 accountHolderType: StripeBankAccountHolderType?,
                 defaultForCurrency: Bool?,
-                metadata: [String: String]?) -> EventLoopFuture<StripeBankAccount>
+                metadata: [String: String]?,
+                context: LoggingContext) -> EventLoopFuture<StripeBankAccount>
     
     /// Deletes a bank account. You can delete destination bank accounts from a [Custom account](https://stripe.com/docs/connect/custom-accounts). \n If a bank account's `default_for_currency` property is true, it can only be deleted if it is the only external account for that currency, and the currency is not the Stripe account's default currency. Otherwise, before deleting the account, you must set another external account to be the default for the currency.
 
@@ -52,7 +54,7 @@ public protocol ExternalAccountsRoutes {
     ///   - account: The connect account associated with this bank account.
     ///   - id: The ID of the bank account to be deleted.
     /// - Returns: A `StripeDeletedObject`.
-    func deleteBankAccount(account: String, id: String) -> EventLoopFuture<StripeDeletedObject>
+    func deleteBankAccount(account: String, id: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject>
     
     /// List all bank accounts belonging to a connect account. You can see a list of the bank accounts belonging to a [Custom account](https://stripe.com/docs/connect/custom-accounts). Note that the 10 most recent external accounts are always available by default on the corresponding Stripe object. If you need more than those 10, you can use this API method and the `limit` and `starting_after` parameters to page through additional bank accounts.
     ///
@@ -60,7 +62,7 @@ public protocol ExternalAccountsRoutes {
     ///   - account: The connect account associated with the bank account(s).
     ///   - filter: A dictionary that will be used for the query parameters. [See More →](https://stripe.com/docs/api/external_account_bank_accounts/list)
     /// - Returns: A `StripeBankAccountList`.
-    func listAll(account: String, filter: [String: Any]?) -> EventLoopFuture<StripeBankAccountList>
+    func listAll(account: String, filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeBankAccountList>
     
     /// Creates a new card. When you create a new card, you must specify a [Custom account](https://stripe.com/docs/connect/custom-accounts) to create it on. \n If the account has no default destination card, then the new card will become the default. However, if the owner already has a default then it will not change. To change the default, you should set `default_for_currency` to `true` when creating a card for a Custom account.
     ///
@@ -71,7 +73,7 @@ public protocol ExternalAccountsRoutes {
     
     ///   - metadata: A set of key-value pairs that you can attach to an external account object. It can be useful for storing additional information about the external account in a structured format.
     /// - Returns: A `StripeCard`.
-    func create(account: String, card: Any, defaultForCurrency: Bool?, metadata: [String: String]?) -> EventLoopFuture<StripeCard>
+    func create(account: String, card: Any, defaultForCurrency: Bool?, metadata: [String: String]?, context: LoggingContext) -> EventLoopFuture<StripeCard>
     
     /// By default, you can see the 10 most recent external accounts stored on a [Custom account](https://stripe.com/docs/connect/custom-accounts) directly on the object, but you can also retrieve details about a specific card stored on the [Custom account](https://stripe.com/docs/connect/custom-accounts).
     ///
@@ -79,7 +81,7 @@ public protocol ExternalAccountsRoutes {
     ///   - account: The connect account associated with this card.
     ///   - id: The ID of the card to retrieve.
     /// - Returns: A `StripeCard`.
-    func retrieve(account: String, id: String) -> EventLoopFuture<StripeCard>
+    func retrieve(account: String, id: String, context: LoggingContext) -> EventLoopFuture<StripeCard>
     
     /// If you need to update only some card details, like the billing address or expiration date, you can do so without having to re-enter the full card details. Stripe also works directly with card networks so that your customers can [continue using your service](https://stripe.com/docs/saving-cards#automatic-card-updates) without interruption.
     /// - Parameters:
@@ -109,7 +111,8 @@ public protocol ExternalAccountsRoutes {
                 expMonth: Int?,
                 expYear: Int?,
                 metadata: [String: String]?,
-                name: String?) -> EventLoopFuture<StripeCard>
+                name: String?,
+                context: LoggingContext) -> EventLoopFuture<StripeCard>
     
     /// Deletes a card. If a card's default_for_currency property is true, it can only be deleted if it is the only external account for that currency, and the currency is not the Stripe account's default currency. Otherwise, before deleting the card, you must set another external account to be the default for the currency.
     ///
@@ -117,7 +120,7 @@ public protocol ExternalAccountsRoutes {
     ///   - account: The connect account associated with this card.
     ///   - id: The ID of the card to be deleted.
     /// - Returns: A `StripeDeletedObject`.
-    func deleteCard(account: String, id: String) -> EventLoopFuture<StripeDeletedObject>
+    func deleteCard(account: String, id: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject>
     
     /// List all cards belonging to a connect account. You can see a list of the cards belonging to a [Custom account](https://stripe.com/docs/connect/custom-accounts). Note that the 10 most recent external accounts are always available by default on the corresponding Stripe object. If you need more than those 10, you can use this API method and the `limit` and `starting_after` parameters to page through additional bank accounts.
     ///
@@ -125,18 +128,18 @@ public protocol ExternalAccountsRoutes {
     ///   - account: The connect account associated with the card(s).
     ///   - filter: A dictionary that will be used for the query parameters. [See More →](https://stripe.com/docs/api/external_account_cards/list)
     /// - Returns: A `StripeCardList`.
-    func listAll(account: String, filter: [String: Any]?) -> EventLoopFuture<StripeCardList>
+    func listAll(account: String, filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeCardList>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
 }
 
 extension ExternalAccountsRoutes {
-    public func create(account: String, bankAccount: Any, defaultForCurrency: Bool? = nil, metadata: [String: String]? = nil) -> EventLoopFuture<StripeBankAccount> {
+    public func create(account: String, bankAccount: Any, defaultForCurrency: Bool? = nil, metadata: [String: String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeBankAccount> {
         return create(account: account, bankAccount: bankAccount, defaultForCurrency: defaultForCurrency, metadata: metadata)
     }
     
-    public func retrieve(account: String, id: String) -> EventLoopFuture<StripeBankAccount> {
+    public func retrieve(account: String, id: String, context: LoggingContext) -> EventLoopFuture<StripeBankAccount> {
         return retrieve(account: account, id: id)
     }
     
@@ -145,7 +148,8 @@ extension ExternalAccountsRoutes {
                        accountHolderName: String? = nil,
                        accountHolderType: StripeBankAccountHolderType? = nil,
                        defaultForCurrency: Bool? = nil,
-                       metadata: [String: String]? = nil) -> EventLoopFuture<StripeBankAccount> {
+                       metadata: [String: String]? = nil,
+                       context: LoggingContext) -> EventLoopFuture<StripeBankAccount> {
         return update(account: account,
                           id: id,
                           accountHolderName: accountHolderName,
@@ -154,19 +158,19 @@ extension ExternalAccountsRoutes {
                           metadata: metadata)
     }
     
-    public func deleteBankAccount(account: String, id: String) -> EventLoopFuture<StripeDeletedObject> {
+    public func deleteBankAccount(account: String, id: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
         return deleteBankAccount(account: account, id: id)
     }
     
-    public func listAll(account: String, filter: [String: Any]? = nil) -> EventLoopFuture<StripeBankAccountList> {
+    public func listAll(account: String, filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeBankAccountList> {
         return listAll(account: account, filter: filter)
     }
     
-    public func create(account: String, card: Any, defaultForCurrency: Bool? = nil, metadata: [String: String]? = nil) -> EventLoopFuture<StripeCard> {
+    public func create(account: String, card: Any, defaultForCurrency: Bool? = nil, metadata: [String: String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeCard> {
         return create(account: account, card: card, defaultForCurrency: defaultForCurrency, metadata: metadata)
     }
     
-    public func retrieve(account: String, id: String) -> EventLoopFuture<StripeCard> {
+    public func retrieve(account: String, id: String, context: LoggingContext) -> EventLoopFuture<StripeCard> {
         return retrieve(account: account, id: id)
     }
     
@@ -182,7 +186,8 @@ extension ExternalAccountsRoutes {
                        expMonth: Int? = nil,
                        expYear: Int? = nil,
                        metadata: [String: String]? = nil,
-                       name: String?) -> EventLoopFuture<StripeCard> {
+                       name: String?,
+                       context: LoggingContext) -> EventLoopFuture<StripeCard> {
         return update(account: account,
                           id: id,
                           addressCity: addressCity,
@@ -198,11 +203,11 @@ extension ExternalAccountsRoutes {
                           name: name)
     }
     
-    public func deleteCard(account: String, id: String) -> EventLoopFuture<StripeDeletedObject> {
+    public func deleteCard(account: String, id: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
         return deleteCard(account: account, id: id)
     }
     
-    public func listAll(account: String, filter: [String: Any]? = nil) -> EventLoopFuture<StripeCardList> {
+    public func listAll(account: String, filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeCardList> {
         return listAll(account: account, filter: filter)
     }
 }
@@ -217,7 +222,7 @@ public struct StripeExternalAccountsRoutes: ExternalAccountsRoutes {
         self.apiHandler = apiHandler
     }
     
-    public func create(account: String, bankAccount: Any, defaultForCurrency: Bool?, metadata: [String: String]?) -> EventLoopFuture<StripeBankAccount> {
+    public func create(account: String, bankAccount: Any, defaultForCurrency: Bool?, metadata: [String: String]?, context: LoggingContext) -> EventLoopFuture<StripeBankAccount> {
         var body: [String: Any] = [:]
         
         if let bankToken = bankAccount as? String {
@@ -237,7 +242,7 @@ public struct StripeExternalAccountsRoutes: ExternalAccountsRoutes {
         return apiHandler.send(method: .POST, path: "\(accounts)/\(account)/external_accounts", body: .string(body.queryParameters), headers: headers)
     }
     
-    public func retrieve(account: String, id: String) -> EventLoopFuture<StripeBankAccount> {
+    public func retrieve(account: String, id: String, context: LoggingContext) -> EventLoopFuture<StripeBankAccount> {
         return apiHandler.send(method: .GET, path: "\(accounts)/\(account)/external_accounts/\(id)", headers: headers)
     }
     
@@ -246,7 +251,8 @@ public struct StripeExternalAccountsRoutes: ExternalAccountsRoutes {
                        accountHolderName: String?,
                        accountHolderType: StripeBankAccountHolderType?,
                        defaultForCurrency: Bool?,
-                       metadata: [String: String]?) -> EventLoopFuture<StripeBankAccount> {
+                       metadata: [String: String]?,
+                       context: LoggingContext) -> EventLoopFuture<StripeBankAccount> {
         var body: [String: Any] = [:]
         
         if let accountHolderName = accountHolderName {
@@ -268,11 +274,11 @@ public struct StripeExternalAccountsRoutes: ExternalAccountsRoutes {
         return apiHandler.send(method: .POST, path: "\(accounts)/\(account)/external_accounts/\(id)", body: .string(body.queryParameters), headers: headers)
     }
     
-    public func deleteBankAccount(account: String, id: String) -> EventLoopFuture<StripeDeletedObject> {
+    public func deleteBankAccount(account: String, id: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
         return apiHandler.send(method: .DELETE, path: "\(accounts)/\(account)/external_accounts/\(id)", headers: headers)
     }
     
-    public func listAll(account: String, filter: [String: Any]?) -> EventLoopFuture<StripeBankAccountList> {
+    public func listAll(account: String, filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeBankAccountList> {
         var queryParams = ""
         if let filter = filter {
             queryParams = filter.queryParameters
@@ -280,7 +286,7 @@ public struct StripeExternalAccountsRoutes: ExternalAccountsRoutes {
         return apiHandler.send(method: .GET, path: "\(accounts)/\(account)/external_accounts", query: queryParams, headers: headers)
     }
     
-    public func create(account: String, card: Any, defaultForCurrency: Bool?, metadata: [String: String]?) -> EventLoopFuture<StripeCard> {
+    public func create(account: String, card: Any, defaultForCurrency: Bool?, metadata: [String: String]?, context: LoggingContext) -> EventLoopFuture<StripeCard> {
         var body: [String: Any] = [:]
         
         if let cardToken = card as? String {
@@ -300,7 +306,7 @@ public struct StripeExternalAccountsRoutes: ExternalAccountsRoutes {
         return apiHandler.send(method: .POST, path: "\(accounts)/\(account)/external_accounts", body: .string(body.queryParameters), headers: headers)
     }
     
-    public func retrieve(account: String, id: String) -> EventLoopFuture<StripeCard> {
+    public func retrieve(account: String, id: String, context: LoggingContext) -> EventLoopFuture<StripeCard> {
         return apiHandler.send(method: .GET, path: "\(accounts)/\(account)/external_accounts/\(id)", headers: headers)
     }
     
@@ -316,7 +322,8 @@ public struct StripeExternalAccountsRoutes: ExternalAccountsRoutes {
                        expMonth: Int?,
                        expYear: Int?,
                        metadata: [String: String]?,
-                       name: String?) -> EventLoopFuture<StripeCard> {
+                       name: String?,
+                       context: LoggingContext) -> EventLoopFuture<StripeCard> {
         var body: [String: Any] = [:]
         
         if let addressCity = addressCity {
@@ -366,11 +373,11 @@ public struct StripeExternalAccountsRoutes: ExternalAccountsRoutes {
         return apiHandler.send(method: .POST, path: "\(accounts)/\(account)/external_accounts/\(id)", body: .string(body.queryParameters), headers: headers)
     }
     
-    public func deleteCard(account: String, id: String) -> EventLoopFuture<StripeDeletedObject> {
+    public func deleteCard(account: String, id: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
         return apiHandler.send(method: .DELETE, path: "\(accounts)/\(account)/external_accounts/\(id)", headers: headers)
     }
     
-    public func listAll(account: String, filter: [String: Any]?) -> EventLoopFuture<StripeCardList> {
+    public func listAll(account: String, filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeCardList> {
         var queryParams = ""
         if let filter = filter {
             queryParams = filter.queryParameters

--- a/Sources/StripeKit/Connect/Persons/PersonRoutes.swift
+++ b/Sources/StripeKit/Connect/Persons/PersonRoutes.swift
@@ -191,11 +191,12 @@ extension PersonRoutes {
                       politicalExposure: politicalExposure,
                       relationship: relationship,
                       ssnLast4: ssnLast4,
-                      verification: verification)
+                      verification: verification,
+                      context: context)
     }
     
     public func retrieve(account: String, person: String, context: LoggingContext) -> EventLoopFuture<StripePerson> {
-        return retrieve(account: account, person: person)
+        return retrieve(account: account, person: person, context: context)
     }
     
     public func update(account: String,
@@ -246,15 +247,16 @@ extension PersonRoutes {
                       politicalExposure: politicalExposure,
                       relationship: relationship,
                       ssnLast4: ssnLast4,
-                      verification: verification)
+                      verification: verification,
+                      context: context)
     }
     
     public func delete(account: String, person: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
-        return delete(account: account, person: person)
+        return delete(account: account, person: person, context: context)
     }
     
     public func listAll(account: String, filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripePersonsList> {
-        return listAll(account: account, filter: filter)
+        return listAll(account: account, filter: filter, context: context)
     }
 }
 
@@ -383,11 +385,11 @@ public struct StripePersonRoutes: PersonRoutes {
             verification.forEach { body["verification[\($0)]"] = $1 }
         }
         
-        return apiHandler.send(method: .POST, path: "\(persons)/\(account)/persons", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(persons)/\(account)/persons", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(account: String, person: String, context: LoggingContext) -> EventLoopFuture<StripePerson> {
-        return apiHandler.send(method: .GET, path: "\(persons)/\(account)/persons/\(person)", headers: headers)
+        return apiHandler.send(method: .GET, path: "\(persons)/\(account)/persons/\(person)", headers: headers, context: context)
     }
     
     public func update(account: String,
@@ -505,11 +507,11 @@ public struct StripePersonRoutes: PersonRoutes {
             verification.forEach { body["verification[\($0)]"] = $1 }
         }
         
-        return apiHandler.send(method: .POST, path: "\(persons)/\(account)/persons/\(person)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(persons)/\(account)/persons/\(person)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func delete(account: String, person: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
-        return apiHandler.send(method: .DELETE, path: "\(persons)/\(account)/persons/\(person)", headers: headers)
+        return apiHandler.send(method: .DELETE, path: "\(persons)/\(account)/persons/\(person)", headers: headers, context: context)
     }
     
     public func listAll(account: String, filter: [String : Any]?, context: LoggingContext) -> EventLoopFuture<StripePersonsList> {
@@ -517,6 +519,6 @@ public struct StripePersonRoutes: PersonRoutes {
         if let filter = filter {
             queryParams = filter.queryParameters
         }
-        return apiHandler.send(method: .GET, path: "\(persons)/\(account)/persons", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(persons)/\(account)/persons", query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Connect/Persons/PersonRoutes.swift
+++ b/Sources/StripeKit/Connect/Persons/PersonRoutes.swift
@@ -7,6 +7,7 @@
 
 import NIO
 import NIOHTTP1
+import Baggage
 
 public protocol PersonRoutes {
     /// Creates a new person.
@@ -58,7 +59,8 @@ public protocol PersonRoutes {
                 politicalExposure: StripePersonPoliticalExposure?,
                 relationship: [String: Any]?,
                 ssnLast4: String?,
-                verification: [String: Any]?) -> EventLoopFuture<StripePerson>
+                verification: [String: Any]?,
+                context: LoggingContext) -> EventLoopFuture<StripePerson>
     
     /// Retrieves an existing person.
     ///
@@ -66,7 +68,7 @@ public protocol PersonRoutes {
     ///   - account: The unique identifier of the account the person is associated with.
     ///   - person: The ID of a person to retrieve.
     /// - Returns: Returns a person object.
-    func retrieve(account: String, person: String) -> EventLoopFuture<StripePerson>
+    func retrieve(account: String, person: String, context: LoggingContext) -> EventLoopFuture<StripePerson>
     
     /// Updates an existing person.
     ///
@@ -119,7 +121,8 @@ public protocol PersonRoutes {
                 politicalExposure: StripePersonPoliticalExposure?,
                 relationship: [String: Any]?,
                 ssnLast4: String?,
-                verification: [String: Any]?) -> EventLoopFuture<StripePerson>
+                verification: [String: Any]?,
+                context: LoggingContext) -> EventLoopFuture<StripePerson>
     
     /// Deletes an existing person’s relationship to the account’s legal entity.
     ///
@@ -127,7 +130,7 @@ public protocol PersonRoutes {
     ///   - account: The unique identifier of the account the person is associated with.
     ///   - person: The ID of a person to update.
     /// - Returns: Returns the deleted person object.
-    func delete(account: String, person: String) -> EventLoopFuture<StripeDeletedObject>
+    func delete(account: String, person: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject>
     
     /// Returns a list of people associated with the account’s legal entity. The people are returned sorted by creation date, with the most recent people appearing first.
     ///
@@ -135,7 +138,7 @@ public protocol PersonRoutes {
     ///   - account: The unique identifier of the account the person is associated with.
     ///   - filter: A dictionary that will be used for the query parameters. [See More →](https://stripe.com/docs/api/persons/list?&lang=curl)
     /// - Returns: A `StripePersonsList`
-    func listAll(account: String, filter: [String: Any]?) -> EventLoopFuture<StripePersonsList>
+    func listAll(account: String, filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripePersonsList>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
@@ -164,7 +167,8 @@ extension PersonRoutes {
                        politicalExposure: StripePersonPoliticalExposure? = nil,
                        relationship: [String: Any]? = nil,
                        ssnLast4: String?,
-                       verification: [String: Any]? = nil) -> EventLoopFuture<StripePerson> {
+                       verification: [String: Any]? = nil,
+                       context: LoggingContext) -> EventLoopFuture<StripePerson> {
         return create(account: account,
                       address: address,
                       addressKana: addressKana,
@@ -190,7 +194,7 @@ extension PersonRoutes {
                       verification: verification)
     }
     
-    public func retrieve(account: String, person: String) -> EventLoopFuture<StripePerson> {
+    public func retrieve(account: String, person: String, context: LoggingContext) -> EventLoopFuture<StripePerson> {
         return retrieve(account: account, person: person)
     }
     
@@ -217,7 +221,8 @@ extension PersonRoutes {
                        politicalExposure: StripePersonPoliticalExposure? = nil,
                        relationship: [String: Any]? = nil,
                        ssnLast4: String? = nil,
-                       verification: [String: Any]? = nil) -> EventLoopFuture<StripePerson> {
+                       verification: [String: Any]? = nil,
+                       context: LoggingContext) -> EventLoopFuture<StripePerson> {
         return update(account: account,
                       person: person,
                       address: address,
@@ -244,11 +249,11 @@ extension PersonRoutes {
                       verification: verification)
     }
     
-    public func delete(account: String, person: String) -> EventLoopFuture<StripeDeletedObject> {
+    public func delete(account: String, person: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
         return delete(account: account, person: person)
     }
     
-    public func listAll(account: String, filter: [String: Any]? = nil) -> EventLoopFuture<StripePersonsList> {
+    public func listAll(account: String, filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripePersonsList> {
         return listAll(account: account, filter: filter)
     }
 }
@@ -286,7 +291,8 @@ public struct StripePersonRoutes: PersonRoutes {
                        politicalExposure: StripePersonPoliticalExposure?,
                        relationship: [String: Any]?,
                        ssnLast4: String?,
-                       verification: [String: Any]?) -> EventLoopFuture<StripePerson> {
+                       verification: [String: Any]?,
+                       context: LoggingContext) -> EventLoopFuture<StripePerson> {
         var body: [String: Any] = [:]
         
         if let address = address {
@@ -380,7 +386,7 @@ public struct StripePersonRoutes: PersonRoutes {
         return apiHandler.send(method: .POST, path: "\(persons)/\(account)/persons", body: .string(body.queryParameters), headers: headers)
     }
     
-    public func retrieve(account: String, person: String) -> EventLoopFuture<StripePerson> {
+    public func retrieve(account: String, person: String, context: LoggingContext) -> EventLoopFuture<StripePerson> {
         return apiHandler.send(method: .GET, path: "\(persons)/\(account)/persons/\(person)", headers: headers)
     }
     
@@ -407,7 +413,8 @@ public struct StripePersonRoutes: PersonRoutes {
                        politicalExposure: StripePersonPoliticalExposure?,
                        relationship: [String: Any]?,
                        ssnLast4: String?,
-                       verification: [String: Any]?) -> EventLoopFuture<StripePerson> {
+                       verification: [String: Any]?,
+                       context: LoggingContext) -> EventLoopFuture<StripePerson> {
         var body: [String: Any] = [:]
         
         if let address = address {
@@ -501,11 +508,11 @@ public struct StripePersonRoutes: PersonRoutes {
         return apiHandler.send(method: .POST, path: "\(persons)/\(account)/persons/\(person)", body: .string(body.queryParameters), headers: headers)
     }
     
-    public func delete(account: String, person: String) -> EventLoopFuture<StripeDeletedObject> {
+    public func delete(account: String, person: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
         return apiHandler.send(method: .DELETE, path: "\(persons)/\(account)/persons/\(person)", headers: headers)
     }
     
-    public func listAll(account: String, filter: [String : Any]?) -> EventLoopFuture<StripePersonsList> {
+    public func listAll(account: String, filter: [String : Any]?, context: LoggingContext) -> EventLoopFuture<StripePersonsList> {
         var queryParams = ""
         if let filter = filter {
             queryParams = filter.queryParameters

--- a/Sources/StripeKit/Connect/TopUp/TopUpRoutes.swift
+++ b/Sources/StripeKit/Connect/TopUp/TopUpRoutes.swift
@@ -87,11 +87,12 @@ extension TopUpRoutes {
                       source: source,
                       statementDescriptor: statementDescriptor,
                       transferGroup: transferGroup,
-                      expand: expand)
+                      expand: expand,
+                      context: context)
     }
     
     public func retrieve(topup: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeTopUp> {
-        return retrieve(topup: topup, expand: expand)
+        return retrieve(topup: topup, expand: expand, context: context)
     }
     
     public func update(topup: String,
@@ -102,15 +103,16 @@ extension TopUpRoutes {
         return update(topup: topup,
                       description: description,
                       metadata: metadata,
-                      expand: expand)
+                      expand: expand,
+                      context: context)
     }
     
     public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeTopUpList> {
-        return listAll(filter: filter)
+        return listAll(filter: filter, context: context)
     }
     
     public func cancel(topup: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeTopUp> {
-        return cancel(topup: topup, expand: expand)
+        return cancel(topup: topup, expand: expand, context: context)
     }
 }
 
@@ -160,7 +162,7 @@ public struct StripeTopUpRoutes: TopUpRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: topups, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: topups, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(topup: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeTopUp> {
@@ -169,7 +171,7 @@ public struct StripeTopUpRoutes: TopUpRoutes {
             queryParams = ["expand": expand].queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: "\(topups)/\(topup)", query: queryParams)
+        return apiHandler.send(method: .GET, path: "\(topups)/\(topup)", query: queryParams, context: context)
     }
     
     public func update(topup: String,
@@ -191,7 +193,7 @@ public struct StripeTopUpRoutes: TopUpRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(topups)/\(topup)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(topups)/\(topup)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeTopUpList> {
@@ -199,7 +201,7 @@ public struct StripeTopUpRoutes: TopUpRoutes {
         if let filter = filter {
             queryParams = filter.queryParameters
         }
-        return apiHandler.send(method: .GET, path: topups, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: topups, query: queryParams, headers: headers, context: context)
     }
     
     public func cancel(topup: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeTopUp> {
@@ -209,6 +211,6 @@ public struct StripeTopUpRoutes: TopUpRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(topups)/\(topup)/cancel", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(topups)/\(topup)/cancel", body: .string(body.queryParameters), headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Connect/Transfer Reversal/TransferReversalRoutes.swift
+++ b/Sources/StripeKit/Connect/Transfer Reversal/TransferReversalRoutes.swift
@@ -79,11 +79,12 @@ extension TransferReversalRoutes {
                       description: description,
                       metadata: metadata,
                       refundApplicationFee: refundApplicationFee,
-                      expand: expand)
+                      expand: expand,
+                      context: context)
     }
     
     public func retrieve(id: String, transfer: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeTransferReversal> {
-        return retrieve(id: id, transfer: transfer, expand: expand)
+        return retrieve(id: id, transfer: transfer, expand: expand, context: context)
     }
     
     public func update(id: String,
@@ -94,11 +95,11 @@ extension TransferReversalRoutes {
         return update(id: id,
                       transfer: transfer,
                       metadata: metadata,
-                      expand: expand)
+                      expand: expand, context: context)
     }
     
     public func listAll(id: String, filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeTransferReversalList> {
-        return listAll(id: id, filter: filter)
+        return listAll(id: id, filter: filter, context: context)
     }
 }
 
@@ -141,7 +142,7 @@ public struct StripeTransferReversalRoutes: TransferReversalRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(transferreversals)/\(id)/reversals", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(transferreversals)/\(id)/reversals", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(id: String, transfer: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeTransferReversal> {
@@ -150,7 +151,7 @@ public struct StripeTransferReversalRoutes: TransferReversalRoutes {
             queryParams = ["expand": expand].queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: "\(transferreversals)/\(id)/reversals/\(id)", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(transferreversals)/\(id)/reversals/\(id)", query: queryParams, headers: headers, context: context)
     }
     
     public func update(id: String,
@@ -167,7 +168,7 @@ public struct StripeTransferReversalRoutes: TransferReversalRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(transferreversals)/\(id)/reversals/\(id)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(transferreversals)/\(id)/reversals/\(id)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func listAll(id: String, filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeTransferReversalList> {
@@ -175,7 +176,7 @@ public struct StripeTransferReversalRoutes: TransferReversalRoutes {
         if let filter = filter {
             queryParams = filter.queryParameters
         }
-        return apiHandler.send(method: .GET, path: "\(transferreversals)/\(id)/reversals", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(transferreversals)/\(id)/reversals", query: queryParams, headers: headers, context: context)
     }
 }
 

--- a/Sources/StripeKit/Connect/Transfer Reversal/TransferReversalRoutes.swift
+++ b/Sources/StripeKit/Connect/Transfer Reversal/TransferReversalRoutes.swift
@@ -7,6 +7,7 @@
 
 import NIO
 import NIOHTTP1
+import Baggage
 
 public protocol TransferReversalRoutes {
     /// When you create a new reversal, you must specify a transfer to create it on.
@@ -26,7 +27,8 @@ public protocol TransferReversalRoutes {
                 description: String?,
                 metadata: [String: String]?,
                 refundApplicationFee: Bool?,
-                expand: [String]?) -> EventLoopFuture<StripeTransferReversal>
+                expand: [String]?,
+                context: LoggingContext) -> EventLoopFuture<StripeTransferReversal>
     
     /// By default, you can see the 10 most recent reversals stored directly on the transfer object, but you can also retrieve details about a specific reversal stored on the transfer.
     ///
@@ -35,7 +37,7 @@ public protocol TransferReversalRoutes {
     ///   - reversal: ID of the transfer reversed.
     ///   - expand: An array of properties to expand.
     /// - Returns: A `StripeTransferReversal`.
-    func retrieve(id: String, transfer: String, expand: [String]?) -> EventLoopFuture<StripeTransferReversal>
+    func retrieve(id: String, transfer: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeTransferReversal>
     
     /// Updates the specified reversal by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
     /// This request only accepts metadata and description as arguments.
@@ -49,7 +51,8 @@ public protocol TransferReversalRoutes {
     func update(id: String,
                 transfer: String,
                 metadata: [String: String]?,
-                expand: [String]?) -> EventLoopFuture<StripeTransferReversal>
+                expand: [String]?,
+                context: LoggingContext) -> EventLoopFuture<StripeTransferReversal>
     
     /// You can see a list of the reversals belonging to a specific transfer. Note that the 10 most recent reversals are always available by default on the transfer object. If you need more than those 10, you can use this API method and the limit and starting_after parameters to page through additional reversals.
     ///
@@ -57,7 +60,7 @@ public protocol TransferReversalRoutes {
     ///   - id: The ID of the transfer whose reversals will be retrieved.
     ///   - filter: A dictionary that will be used for the query parameters. [See More →](https://stripe.com/docs/api/transfer_reversals/list)
     /// - Returns: A `StripeTransferReversalList`.
-    func listAll(id: String, filter: [String: Any]?) -> EventLoopFuture<StripeTransferReversalList>
+    func listAll(id: String, filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeTransferReversalList>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
@@ -69,7 +72,8 @@ extension TransferReversalRoutes {
                        description: String? = nil,
                        metadata: [String: String]? = nil,
                        refundApplicationFee: Bool? = nil,
-                       expand: [String]? = nil) -> EventLoopFuture<StripeTransferReversal> {
+                       expand: [String]? = nil,
+                       context: LoggingContext) -> EventLoopFuture<StripeTransferReversal> {
         return create(id: id,
                       amount: amount,
                       description: description,
@@ -78,21 +82,22 @@ extension TransferReversalRoutes {
                       expand: expand)
     }
     
-    public func retrieve(id: String, transfer: String, expand: [String]? = nil) -> EventLoopFuture<StripeTransferReversal> {
+    public func retrieve(id: String, transfer: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeTransferReversal> {
         return retrieve(id: id, transfer: transfer, expand: expand)
     }
     
     public func update(id: String,
                        transfer: String,
                        metadata: [String: String]? = nil,
-                       expand: [String]? = nil) -> EventLoopFuture<StripeTransferReversal> {
+                       expand: [String]? = nil,
+                       context: LoggingContext) -> EventLoopFuture<StripeTransferReversal> {
         return update(id: id,
                       transfer: transfer,
                       metadata: metadata,
                       expand: expand)
     }
     
-    public func listAll(id: String, filter: [String: Any]? = nil) -> EventLoopFuture<StripeTransferReversalList> {
+    public func listAll(id: String, filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeTransferReversalList> {
         return listAll(id: id, filter: filter)
     }
 }
@@ -112,7 +117,8 @@ public struct StripeTransferReversalRoutes: TransferReversalRoutes {
                        description: String?,
                        metadata: [String: String]?,
                        refundApplicationFee: Bool?,
-                       expand: [String]?) -> EventLoopFuture<StripeTransferReversal> {
+                       expand: [String]?,
+                       context: LoggingContext) -> EventLoopFuture<StripeTransferReversal> {
         var body: [String: Any] = [:]
         
         if let amount = amount {
@@ -138,7 +144,7 @@ public struct StripeTransferReversalRoutes: TransferReversalRoutes {
         return apiHandler.send(method: .POST, path: "\(transferreversals)/\(id)/reversals", body: .string(body.queryParameters), headers: headers)
     }
     
-    public func retrieve(id: String, transfer: String, expand: [String]?) -> EventLoopFuture<StripeTransferReversal> {
+    public func retrieve(id: String, transfer: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeTransferReversal> {
         var queryParams = ""
         if let expand = expand {
             queryParams = ["expand": expand].queryParameters
@@ -150,7 +156,8 @@ public struct StripeTransferReversalRoutes: TransferReversalRoutes {
     public func update(id: String,
                        transfer: String,
                        metadata: [String: String]?,
-                       expand: [String]?) -> EventLoopFuture<StripeTransferReversal> {
+                       expand: [String]?,
+                       context: LoggingContext) -> EventLoopFuture<StripeTransferReversal> {
         var body: [String: Any] = [:]
         if let metadata = metadata {
             metadata.forEach { body["metadata[\($0)]"] = $1 }
@@ -163,7 +170,7 @@ public struct StripeTransferReversalRoutes: TransferReversalRoutes {
         return apiHandler.send(method: .POST, path: "\(transferreversals)/\(id)/reversals/\(id)", body: .string(body.queryParameters), headers: headers)
     }
     
-    public func listAll(id: String, filter: [String: Any]?) -> EventLoopFuture<StripeTransferReversalList> {
+    public func listAll(id: String, filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeTransferReversalList> {
         var queryParams = ""
         if let filter = filter {
             queryParams = filter.queryParameters

--- a/Sources/StripeKit/Connect/Transfers/TransferRoutes.swift
+++ b/Sources/StripeKit/Connect/Transfers/TransferRoutes.swift
@@ -85,11 +85,12 @@ extension TransferRoutes {
                       sourceTransaction: sourceTransaction,
                       sourceType: sourceType,
                       transferGroup: transferGroup,
-                      expand: expand)
+                      expand: expand,
+                      context: context)
     }
     
     public func retrieve(transfer: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeTransfer> {
-        return retrieve(transfer: transfer, expand: expand)
+        return retrieve(transfer: transfer, expand: expand, context: context)
     }
     
     public func update(transfer: String,
@@ -100,11 +101,12 @@ extension TransferRoutes {
         return update(transfer: transfer,
                       description: description,
                       metadata: metadata,
-                      expand: expand)
+                      expand: expand,
+                      context: context)
     }
     
     public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeTransferList> {
-        return listAll(filter: filter)
+        return listAll(filter: filter, context: context)
     }
 }
 
@@ -156,7 +158,7 @@ public struct StripeTransferRoutes: TransferRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: transfers, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: transfers, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(transfer: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeTransfer> {
@@ -164,7 +166,7 @@ public struct StripeTransferRoutes: TransferRoutes {
         if let expand = expand {
             queryParams = ["expand": expand].queryParameters
         }
-        return apiHandler.send(method: .GET, path: "\(transfers)/\(transfer)", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(transfers)/\(transfer)", query: queryParams, headers: headers, context: context)
     }
     
     public func update(transfer: String,
@@ -186,7 +188,7 @@ public struct StripeTransferRoutes: TransferRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(transfers)/\(transfer)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(transfers)/\(transfer)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeTransferList> {
@@ -194,6 +196,6 @@ public struct StripeTransferRoutes: TransferRoutes {
         if let filter = filter {
             queryParams = filter.queryParameters
         }
-        return apiHandler.send(method: .GET, path: transfers, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: transfers, query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Core Resources/Balance Transactions/BalanceTransactionRoutes.swift
+++ b/Sources/StripeKit/Core Resources/Balance Transactions/BalanceTransactionRoutes.swift
@@ -28,11 +28,11 @@ public protocol BalanceTransactionRoutes {
 
 extension BalanceTransactionRoutes {
     public func retrieve(id: String, context: LoggingContext) -> EventLoopFuture<StripeBalanceTransaction> {
-        return retrieve(id: id)
+        return retrieve(id: id, context: context)
     }
     
     public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeBalanceTransactionList> {
-        return listAll(filter: filter)
+        return listAll(filter: filter, context: context)
     }
 }
 
@@ -48,7 +48,7 @@ public struct StripeBalanceTransactionRoutes: BalanceTransactionRoutes {
     }
     
     public func retrieve(id: String, context: LoggingContext) -> EventLoopFuture<StripeBalanceTransaction> {
-        return apiHandler.send(method: .GET, path: balanceTransaction + id, headers: headers)
+        return apiHandler.send(method: .GET, path: balanceTransaction + id, headers: headers, context: context)
     }
     
     public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeBalanceTransactionList> {
@@ -56,6 +56,6 @@ public struct StripeBalanceTransactionRoutes: BalanceTransactionRoutes {
         if let filter = filter {
             queryParams = filter.queryParameters
         }
-        return apiHandler.send(method: .GET, path: balanceTransactions, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: balanceTransactions, query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Core Resources/Balance Transactions/BalanceTransactionRoutes.swift
+++ b/Sources/StripeKit/Core Resources/Balance Transactions/BalanceTransactionRoutes.swift
@@ -7,30 +7,31 @@
 
 import NIO
 import NIOHTTP1
+import Baggage
 
 public protocol BalanceTransactionRoutes {
     /// Retrieves the balance transaction with the given ID.
     ///
     /// - Parameter id: The ID of the desired balance transaction, as found on any API object that affects the balance (e.g., a charge or transfer).
     /// - Returns: A `StripeBalanceTransaction`.
-    func retrieve(id: String) -> EventLoopFuture<StripeBalanceTransaction>
+    func retrieve(id: String, context: LoggingContext) -> EventLoopFuture<StripeBalanceTransaction>
     
     /// Returns a list of transactions that have contributed to the Stripe account balance (e.g., charges, transfers, and so forth). The transactions are returned in sorted order, with the most recent transactions appearing first.
     ///
     /// - Parameter filter: A dictionary that will be used for the query parameters. [See More →](https://stripe.com/docs/api/balance/balance_history).
     /// - Returns: A `StripeBalanceTransactionList`.
-    func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeBalanceTransactionList>
+    func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeBalanceTransactionList>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
 }
 
 extension BalanceTransactionRoutes {
-    public func retrieve(id: String) -> EventLoopFuture<StripeBalanceTransaction> {
+    public func retrieve(id: String, context: LoggingContext) -> EventLoopFuture<StripeBalanceTransaction> {
         return retrieve(id: id)
     }
     
-    public func listAll(filter: [String: Any]? = nil) -> EventLoopFuture<StripeBalanceTransactionList> {
+    public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeBalanceTransactionList> {
         return listAll(filter: filter)
     }
 }
@@ -46,11 +47,11 @@ public struct StripeBalanceTransactionRoutes: BalanceTransactionRoutes {
         self.apiHandler = apiHandler
     }
     
-    public func retrieve(id: String) -> EventLoopFuture<StripeBalanceTransaction> {
+    public func retrieve(id: String, context: LoggingContext) -> EventLoopFuture<StripeBalanceTransaction> {
         return apiHandler.send(method: .GET, path: balanceTransaction + id, headers: headers)
     }
     
-    public func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeBalanceTransactionList> {
+    public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeBalanceTransactionList> {
         var queryParams = ""
         if let filter = filter {
             queryParams = filter.queryParameters

--- a/Sources/StripeKit/Core Resources/Balance/BalanceRoutes.swift
+++ b/Sources/StripeKit/Core Resources/Balance/BalanceRoutes.swift
@@ -8,19 +8,20 @@
 
 import NIO
 import NIOHTTP1
+import Baggage
 
 public protocol BalanceRoutes {
     /// Retrieves the current account balance, based on the authentication that was used to make the request. For a sample request, see [Accounting for negative balances](https://stripe.com/docs/connect/account-balances#accounting-for-negative-balances).
     ///
     /// - Returns: A `StripeBalance`.
-    func retrieve() -> EventLoopFuture<StripeBalance>
+    func retrieve(context: LoggingContext) -> EventLoopFuture<StripeBalance>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
 }
 
 extension BalanceRoutes {
-    public func retrieve() -> EventLoopFuture<StripeBalance> {
+    public func retrieve(context: LoggingContext) -> EventLoopFuture<StripeBalance> {
         return retrieve()
     }
 }
@@ -35,7 +36,7 @@ public struct StripeBalanceRoutes: BalanceRoutes {
         self.apiHandler = apiHandler
     }
     
-    public func retrieve() -> EventLoopFuture<StripeBalance> {
+    public func retrieve(context: LoggingContext) -> EventLoopFuture<StripeBalance> {
         return apiHandler.send(method: .GET, path: balance, headers: headers)
     }
 }

--- a/Sources/StripeKit/Core Resources/Balance/BalanceRoutes.swift
+++ b/Sources/StripeKit/Core Resources/Balance/BalanceRoutes.swift
@@ -22,7 +22,7 @@ public protocol BalanceRoutes {
 
 extension BalanceRoutes {
     public func retrieve(context: LoggingContext) -> EventLoopFuture<StripeBalance> {
-        return retrieve()
+        return retrieve(context: context)
     }
 }
 
@@ -37,6 +37,6 @@ public struct StripeBalanceRoutes: BalanceRoutes {
     }
     
     public func retrieve(context: LoggingContext) -> EventLoopFuture<StripeBalance> {
-        return apiHandler.send(method: .GET, path: balance, headers: headers)
+        return apiHandler.send(method: .GET, path: balance, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Core Resources/Charges/ChargeRoutes.swift
+++ b/Sources/StripeKit/Core Resources/Charges/ChargeRoutes.swift
@@ -147,11 +147,12 @@ extension ChargeRoutes {
                       statementDescriptorSuffix: statementDescriptorSuffix,
                       transferData: transferData,
                       transferGroup: transferGroup,
-                      expand: expand)
+                      expand: expand,
+                      context: context)
     }
     
     public func retrieve(charge: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeCharge> {
-        return retrieve(charge: charge, expand: expand)
+        return retrieve(charge: charge, expand: expand, context: context)
     }
     
     public func update(charge chargeId: String,
@@ -172,7 +173,8 @@ extension ChargeRoutes {
                       receiptEmail: receiptEmail,
                       shipping: shipping,
                       transferGroup: transferGroup,
-                      expand: expand)
+                      expand: expand,
+                      context: context)
     }
     
     public func capture(charge: String,
@@ -193,11 +195,12 @@ extension ChargeRoutes {
                        statementDescriptorSuffix: statementDescriptorSuffix,
                        transferData: transferData,
                        transferGroup: transferGroup,
-                       expand: expand)
+                       expand: expand,
+                       context: context)
     }
     
     public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeChargesList> {
-        return listAll(filter: filter)
+        return listAll(filter: filter, context: context)
     }
 }
 
@@ -290,7 +293,7 @@ public struct StripeChargeRoutes: ChargeRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: charge, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: charge, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(charge: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeCharge> {
@@ -298,7 +301,7 @@ public struct StripeChargeRoutes: ChargeRoutes {
         if let expand = expand {
             queryParams = ["expand": expand].queryParameters
         }
-        return apiHandler.send(method: .GET, path: charges + charge, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: charges + charge, query: queryParams, headers: headers, context: context)
     }
     
     public func update(charge: String,
@@ -345,7 +348,7 @@ public struct StripeChargeRoutes: ChargeRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: charges + charge, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: charges + charge, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func capture(charge: String,
@@ -392,7 +395,7 @@ public struct StripeChargeRoutes: ChargeRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: charges + charge + "/capture", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: charges + charge + "/capture", body: .string(body.queryParameters), headers: headers, context: context)
     }
 
     public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeChargesList> {
@@ -401,6 +404,6 @@ public struct StripeChargeRoutes: ChargeRoutes {
             queryParams = filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: charge, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: charge, query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Core Resources/Customers/CustomerRoutes.swift
+++ b/Sources/StripeKit/Core Resources/Customers/CustomerRoutes.swift
@@ -8,6 +8,7 @@
 
 import NIO
 import NIOHTTP1
+import Baggage
 
 public protocol CustomerRoutes {
     /// Creates a new customer object.
@@ -51,7 +52,8 @@ public protocol CustomerRoutes {
                 source: Any?,
                 taxExempt: StripeCustomerTaxExempt?,
                 taxIdData: [[String: Any]]?,
-                expand: [String]?) -> EventLoopFuture<StripeCustomer>
+                expand: [String]?,
+                context: LoggingContext) -> EventLoopFuture<StripeCustomer>
     
     
     /// Retrieves the details of an existing customer. You need only supply the unique customer identifier that was returned upon customer creation.
@@ -59,7 +61,7 @@ public protocol CustomerRoutes {
     /// - Parameter customer: The identifier of the customer to be retrieved.
     /// - Parameter expand: An array of properties to expand.
     /// - Returns: A `StripeCustomer`.
-    func retrieve(customer: String, expand: [String]?) -> EventLoopFuture<StripeCustomer>
+    func retrieve(customer: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeCustomer>
     
     /// Updates the specified customer by setting the values of the parameters passed. Any parameters not provided will be left unchanged. For example, if you pass the source parameter, that becomes the customer’s active source (e.g., a card) to be used for all charges in the future. When you update a customer to a new valid card source by passing the source parameter: for each of the customer’s current subscriptions, if the subscription bills automatically and is in the `past_due` state, then the latest open invoice for the subscription with automatic collection enabled will be retried. This retry will not count as an automatic retry, and will not affect the next regularly scheduled payment for the invoice. Changing the default_source for a customer will not trigger this behavior. \n This request accepts mostly the same arguments as the customer creation call.
     ///
@@ -102,20 +104,21 @@ public protocol CustomerRoutes {
                 shipping: [String: Any]?,
                 source: Any?,
                 taxExempt: StripeCustomerTaxExempt?,
-                expand: [String]?) -> EventLoopFuture<StripeCustomer>
+                expand: [String]?,
+                context: LoggingContext) -> EventLoopFuture<StripeCustomer>
     
     
     /// Permanently deletes a customer. It cannot be undone. Also immediately cancels any active subscriptions on the customer.
     ///
     /// - Parameter customer: The identifier of the customer to be deleted.
     /// - Returns: A `StripeDeletedObject`.
-    func delete(customer: String) -> EventLoopFuture<StripeDeletedObject>
+    func delete(customer: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject>
     
     /// Returns a list of your customers. The customers are returned sorted by creation date, with the most recent customers appearing first.
     ///
     /// - Parameter filter: A dictionary that will be used for the query parameters. [See More →](https://stripe.com/docs/api/customers/list).
     /// - Returns: A `StripeCustomerList`.
-    func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeCustomerList>
+    func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeCustomerList>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
@@ -140,7 +143,8 @@ extension CustomerRoutes {
                        source: Any? = nil,
                        taxExempt: StripeCustomerTaxExempt? = nil,
                        taxIdData: [[String: Any]]? = nil,
-                       expand: [String]? = nil) -> EventLoopFuture<StripeCustomer> {
+                       expand: [String]? = nil,
+                       context: LoggingContext) -> EventLoopFuture<StripeCustomer> {
         return create(address: address,
                       balance: balance,
                       coupon: coupon,
@@ -162,7 +166,7 @@ extension CustomerRoutes {
                       expand: expand)
     }
     
-    public func retrieve(customer: String, expand: [String]? = nil) -> EventLoopFuture<StripeCustomer> {
+    public func retrieve(customer: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeCustomer> {
         return retrieve(customer: customer, expand: expand)
     }
     
@@ -184,7 +188,8 @@ extension CustomerRoutes {
                        shipping: [String: Any]? = nil,
                        source: Any? = nil,
                        taxExempt: StripeCustomerTaxExempt? = nil,
-                       expand: [String]? = nil) -> EventLoopFuture<StripeCustomer> {
+                       expand: [String]? = nil,
+                       context: LoggingContext) -> EventLoopFuture<StripeCustomer> {
         return update(customer: customer,
                       address: address,
                       balance: balance,
@@ -206,11 +211,11 @@ extension CustomerRoutes {
                       expand: expand)
     }
     
-    public func delete(customer: String) -> EventLoopFuture<StripeDeletedObject> {
+    public func delete(customer: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
         return delete(customer: customer)
     }
     
-    public func listAll(filter: [String: Any]? = nil) -> EventLoopFuture<StripeCustomerList> {
+    public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeCustomerList> {
         return listAll(filter: filter)
     }
 }
@@ -244,7 +249,8 @@ public struct StripeCustomerRoutes: CustomerRoutes {
                        source: Any?,
                        taxExempt: StripeCustomerTaxExempt?,
                        taxIdData: [[String: Any]]?,
-                       expand: [String]?) -> EventLoopFuture<StripeCustomer> {
+                       expand: [String]?,
+                       context: LoggingContext) -> EventLoopFuture<StripeCustomer> {
         var body: [String: Any] = [:]
         
         if let address = address {
@@ -330,7 +336,7 @@ public struct StripeCustomerRoutes: CustomerRoutes {
         return apiHandler.send(method: .POST, path: customers, body: .string(body.queryParameters), headers: headers)
     }
     
-    public func retrieve(customer: String, expand: [String]?) -> EventLoopFuture<StripeCustomer> {
+    public func retrieve(customer: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeCustomer> {
         var queryParams = ""
         if let expand = expand {
             queryParams = ["expand": expand].queryParameters
@@ -357,7 +363,8 @@ public struct StripeCustomerRoutes: CustomerRoutes {
                        shipping: [String: Any]?,
                        source: Any?,
                        taxExempt: StripeCustomerTaxExempt?,
-                       expand: [String]?) -> EventLoopFuture<StripeCustomer> {
+                       expand: [String]?,
+                       context: LoggingContext) -> EventLoopFuture<StripeCustomer> {
         var body: [String: Any] = [:]
         
         if let address = address {
@@ -439,11 +446,11 @@ public struct StripeCustomerRoutes: CustomerRoutes {
         return apiHandler.send(method: .POST, path: self.customer + customer, body: .string(body.queryParameters), headers: headers)
     }
     
-    public func delete(customer: String) -> EventLoopFuture<StripeDeletedObject> {
+    public func delete(customer: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
         return apiHandler.send(method: .DELETE, path: self.customer + customer, headers: headers)
     }
     
-    public func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeCustomerList> {
+    public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeCustomerList> {
         var queryParams = ""
         if let filter = filter {
             queryParams = filter.queryParameters

--- a/Sources/StripeKit/Core Resources/Customers/CustomerRoutes.swift
+++ b/Sources/StripeKit/Core Resources/Customers/CustomerRoutes.swift
@@ -163,11 +163,12 @@ extension CustomerRoutes {
                       source: source,
                       taxExempt: taxExempt,
                       taxIdData: taxIdData,
-                      expand: expand)
+                      expand: expand,
+                      context: context)
     }
     
     public func retrieve(customer: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeCustomer> {
-        return retrieve(customer: customer, expand: expand)
+        return retrieve(customer: customer, expand: expand, context: context)
     }
     
     public func update(customer: String,
@@ -208,15 +209,16 @@ extension CustomerRoutes {
                       shipping: shipping,
                       source: source,
                       taxExempt: taxExempt,
-                      expand: expand)
+                      expand: expand,
+                      context: context)
     }
     
     public func delete(customer: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
-        return delete(customer: customer)
+        return delete(customer: customer, context: context)
     }
     
     public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeCustomerList> {
-        return listAll(filter: filter)
+        return listAll(filter: filter, context: context)
     }
 }
 
@@ -333,7 +335,7 @@ public struct StripeCustomerRoutes: CustomerRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: customers, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: customers, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(customer: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeCustomer> {
@@ -342,7 +344,7 @@ public struct StripeCustomerRoutes: CustomerRoutes {
             queryParams = ["expand": expand].queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: self.customer + customer, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: self.customer + customer, query: queryParams, headers: headers, context: context)
     }
     
     public func update(customer: String,
@@ -443,11 +445,11 @@ public struct StripeCustomerRoutes: CustomerRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: self.customer + customer, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: self.customer + customer, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func delete(customer: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
-        return apiHandler.send(method: .DELETE, path: self.customer + customer, headers: headers)
+        return apiHandler.send(method: .DELETE, path: self.customer + customer, headers: headers, context: context)
     }
     
     public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeCustomerList> {
@@ -456,6 +458,6 @@ public struct StripeCustomerRoutes: CustomerRoutes {
             queryParams = filter.queryParameters
         }
 
-        return apiHandler.send(method: .GET, path: customers, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: customers, query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Core Resources/Disputes/DisputeRoutes.swift
+++ b/Sources/StripeKit/Core Resources/Disputes/DisputeRoutes.swift
@@ -55,7 +55,7 @@ public protocol DisputeRoutes {
 
 extension DisputeRoutes {
     public func retrieve(dispute: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeDispute> {
-        return retrieve(dispute: dispute, expand: expand)
+        return retrieve(dispute: dispute, expand: expand, context: context)
     }
     
     public func update(dispute: String,
@@ -68,15 +68,16 @@ extension DisputeRoutes {
                       evidence: evidence,
                       metadata: metadata,
                       submit: submit,
-                      expand: expand)
+                      expand: expand,
+                      context: context)
     }
     
     public func close(dispute: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeDispute> {
-        return close(dispute: dispute, expand: expand)
+        return close(dispute: dispute, expand: expand, context: context)
     }
     
     public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeDisputeList> {
-        return listAll(filter: filter)
+        return listAll(filter: filter, context: context)
     }
 }
 
@@ -96,7 +97,7 @@ public struct StripeDisputeRoutes: DisputeRoutes {
             queryParams = ["expand": expand].queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: "\(disputes)/\(dispute)", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(disputes)/\(dispute)", query: queryParams, headers: headers, context: context)
     }
     
     public func update(dispute: String,
@@ -123,7 +124,7 @@ public struct StripeDisputeRoutes: DisputeRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(disputes)/\(dispute)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(disputes)/\(dispute)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func close(dispute: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeDispute> {
@@ -133,7 +134,7 @@ public struct StripeDisputeRoutes: DisputeRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(disputes)/\(dispute)/close", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(disputes)/\(dispute)/close", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func listAll(filter: [String : Any]?, context: LoggingContext) -> EventLoopFuture<StripeDisputeList> {
@@ -142,6 +143,6 @@ public struct StripeDisputeRoutes: DisputeRoutes {
             queryParams = filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: disputes, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: disputes, query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Core Resources/Disputes/DisputeRoutes.swift
+++ b/Sources/StripeKit/Core Resources/Disputes/DisputeRoutes.swift
@@ -8,6 +8,7 @@
 
 import NIO
 import NIOHTTP1
+import Baggage
 
 public protocol DisputeRoutes {
     /// Retrieves the dispute with the given ID.
@@ -16,7 +17,7 @@ public protocol DisputeRoutes {
     ///   - dispute: ID of dispute to retrieve.
     ///   - expand: An array of properties to expand.
     /// - Returns: A `StripeDispute`.
-    func retrieve(dispute: String, expand: [String]?) -> EventLoopFuture<StripeDispute>
+    func retrieve(dispute: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeDispute>
     
     /// When you get a dispute, contacting your customer is always the best first step. If that doesn’t work, you can submit evidence to help us resolve the dispute in your favor. You can do this in your [dashboard](https://dashboard.stripe.com/disputes), but if you prefer, you can use the API to submit evidence programmatically. \n Depending on your dispute type, different evidence fields will give you a better chance of winning your dispute. To figure out which evidence fields to provide, see our [guide to dispute types](https://stripe.com/docs/disputes/categories).
     ///
@@ -31,7 +32,8 @@ public protocol DisputeRoutes {
                 evidence: [String: Any]?,
                 metadata: [String: String]?,
                 submit: Bool?,
-                expand: [String]?) -> EventLoopFuture<StripeDispute>
+                expand: [String]?,
+                context: LoggingContext) -> EventLoopFuture<StripeDispute>
     
     /// Closing the dispute for a charge indicates that you do not have any evidence to submit and are essentially dismissing the dispute, acknowledging it as lost. \n The status of the dispute will change from `needs_response` to `lost`. Closing a dispute is irreversible.
     ///
@@ -39,20 +41,20 @@ public protocol DisputeRoutes {
     ///   - dispute: ID of the dispute to close.
     ///   - expand: An array of properties to expand.
     /// - Returns: A `StripeDispute`.
-    func close(dispute: String, expand: [String]?) -> EventLoopFuture<StripeDispute>
+    func close(dispute: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeDispute>
     
     /// Returns a list of your disputes.
     ///
     /// - Parameter filter: A dictionary that contains the filters. More info [here](https://stripe.com/docs/api/disputes/list).
     /// - Returns: A `StripeDisputeList`.
-    func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeDisputeList>
+    func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeDisputeList>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
 }
 
 extension DisputeRoutes {
-    public func retrieve(dispute: String, expand: [String]? = nil) -> EventLoopFuture<StripeDispute> {
+    public func retrieve(dispute: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeDispute> {
         return retrieve(dispute: dispute, expand: expand)
     }
     
@@ -60,7 +62,8 @@ extension DisputeRoutes {
                        evidence: [String: Any]? = nil,
                        metadata: [String: String]? = nil,
                        submit: Bool? = nil,
-                       expand: [String]? = nil) -> EventLoopFuture<StripeDispute> {
+                       expand: [String]? = nil,
+                       context: LoggingContext) -> EventLoopFuture<StripeDispute> {
         return update(dispute: dispute,
                       evidence: evidence,
                       metadata: metadata,
@@ -68,11 +71,11 @@ extension DisputeRoutes {
                       expand: expand)
     }
     
-    public func close(dispute: String, expand: [String]? = nil) -> EventLoopFuture<StripeDispute> {
+    public func close(dispute: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeDispute> {
         return close(dispute: dispute, expand: expand)
     }
     
-    public func listAll(filter: [String: Any]? = nil) -> EventLoopFuture<StripeDisputeList> {
+    public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeDisputeList> {
         return listAll(filter: filter)
     }
 }
@@ -87,7 +90,7 @@ public struct StripeDisputeRoutes: DisputeRoutes {
         self.apiHandler = apiHandler
     }
     
-    public func retrieve(dispute: String, expand: [String]?) -> EventLoopFuture<StripeDispute> {
+    public func retrieve(dispute: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeDispute> {
         var queryParams = ""
         if let expand = expand {
             queryParams = ["expand": expand].queryParameters
@@ -100,7 +103,8 @@ public struct StripeDisputeRoutes: DisputeRoutes {
                        evidence: [String: Any]?,
                        metadata: [String: String]?,
                        submit: Bool?,
-                       expand: [String]?) -> EventLoopFuture<StripeDispute> {
+                       expand: [String]?,
+                       context: LoggingContext) -> EventLoopFuture<StripeDispute> {
         var body: [String: Any] = [:]
         
         if let evidence = evidence {
@@ -122,7 +126,7 @@ public struct StripeDisputeRoutes: DisputeRoutes {
         return apiHandler.send(method: .POST, path: "\(disputes)/\(dispute)", body: .string(body.queryParameters), headers: headers)
     }
     
-    public func close(dispute: String, expand: [String]?) -> EventLoopFuture<StripeDispute> {
+    public func close(dispute: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeDispute> {
         var body: [String: Any] = [:]
         
         if let expand = expand {
@@ -132,7 +136,7 @@ public struct StripeDisputeRoutes: DisputeRoutes {
         return apiHandler.send(method: .POST, path: "\(disputes)/\(dispute)/close", body: .string(body.queryParameters), headers: headers)
     }
     
-    public func listAll(filter: [String : Any]?) -> EventLoopFuture<StripeDisputeList> {
+    public func listAll(filter: [String : Any]?, context: LoggingContext) -> EventLoopFuture<StripeDisputeList> {
         var queryParams = ""
         if let filter = filter {
             queryParams = filter.queryParameters

--- a/Sources/StripeKit/Core Resources/Events/EventRoutes.swift
+++ b/Sources/StripeKit/Core Resources/Events/EventRoutes.swift
@@ -7,26 +7,27 @@
 
 import NIO
 import NIOHTTP1
+import Baggage
 
 public protocol EventRoutes {
     /// Retrieves the details of an event. Supply the unique identifier of the event, which you might have received in a webhook.
     /// - Parameter id: The identifier of the event to be retrieved.
-    func retrieve(id: String) -> EventLoopFuture<StripeEvent>
+    func retrieve(id: String, context: LoggingContext) -> EventLoopFuture<StripeEvent>
     
     /// List events, going back up to 30 days. Each event data is rendered according to Stripe API version at its creation time, specified in event object `api_version` attribute (not according to your current Stripe API version or `Stripe-Version` header).
     /// - Parameter filter: A dictionary that contains the filters. More info [here](https://stripe.com/docs/api/events/list)
-    func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeEventList>
+    func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeEventList>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
 }
 
 extension EventRoutes {
-    func retrieve(id: String) -> EventLoopFuture<StripeEvent> {
+    func retrieve(id: String, context: LoggingContext) -> EventLoopFuture<StripeEvent> {
         return retrieve(id: id)
     }
     
-    func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeEventList> {
+    func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeEventList> {
         return listAll(filter: filter)
     }
 }
@@ -41,11 +42,11 @@ public struct StripeEventRoutes: EventRoutes {
         self.apiHandler = apiHandler
     }
     
-    public func retrieve(id: String) -> EventLoopFuture<StripeEvent> {
+    public func retrieve(id: String, context: LoggingContext) -> EventLoopFuture<StripeEvent> {
         return apiHandler.send(method: .GET, path: "\(events)/\(id)", headers: headers)
     }
     
-    public func listAll(filter: [String : Any]?) -> EventLoopFuture<StripeEventList> {
+    public func listAll(filter: [String : Any]?, context: LoggingContext) -> EventLoopFuture<StripeEventList> {
         var queryParams = ""
         if let filter = filter {
             queryParams = filter.queryParameters

--- a/Sources/StripeKit/Core Resources/Events/EventRoutes.swift
+++ b/Sources/StripeKit/Core Resources/Events/EventRoutes.swift
@@ -24,11 +24,11 @@ public protocol EventRoutes {
 
 extension EventRoutes {
     func retrieve(id: String, context: LoggingContext) -> EventLoopFuture<StripeEvent> {
-        return retrieve(id: id)
+        return retrieve(id: id, context: context)
     }
     
     func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeEventList> {
-        return listAll(filter: filter)
+        return listAll(filter: filter, context: context)
     }
 }
 
@@ -43,7 +43,7 @@ public struct StripeEventRoutes: EventRoutes {
     }
     
     public func retrieve(id: String, context: LoggingContext) -> EventLoopFuture<StripeEvent> {
-        return apiHandler.send(method: .GET, path: "\(events)/\(id)", headers: headers)
+        return apiHandler.send(method: .GET, path: "\(events)/\(id)", headers: headers, context: context)
     }
     
     public func listAll(filter: [String : Any]?, context: LoggingContext) -> EventLoopFuture<StripeEventList> {
@@ -52,6 +52,6 @@ public struct StripeEventRoutes: EventRoutes {
             queryParams = filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: events, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: events, query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Core Resources/File Links/FileLinkRoutes.swift
+++ b/Sources/StripeKit/Core Resources/File Links/FileLinkRoutes.swift
@@ -67,11 +67,12 @@ extension FileLinkRoutes {
         return create(file: file,
                       expiresAt: expiresAt,
                       metadata: metadata,
-                      expand: expand)
+                      expand: expand,
+                      context: context)
     }
     
     public func retrieve(link: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeFileLink> {
-        return retrieve(link: link, expand: expand)
+        return retrieve(link: link, expand: expand, context: context)
     }
     
     public func update(link: String,
@@ -82,11 +83,12 @@ extension FileLinkRoutes {
         return update(link: link,
                       expiresAt: expiresAt,
                       metadata: metadata,
-                      expand: expand)
+                      expand: expand,
+                      context: context)
     }
     
     public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeFileLinkList> {
-        return listAll(filter: filter)
+        return listAll(filter: filter, context: context)
     }
 }
 
@@ -118,7 +120,7 @@ public struct StripeFileLinkRoutes: FileLinkRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: filelinks, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: filelinks, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(link: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeFileLink> {
@@ -127,7 +129,7 @@ public struct StripeFileLinkRoutes: FileLinkRoutes {
             queryParams = ["expand": expand].queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: "\(filelinks)/\(link)", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(filelinks)/\(link)", query: queryParams, headers: headers, context: context)
     }
     
     public func update(link: String,
@@ -153,15 +155,15 @@ public struct StripeFileLinkRoutes: FileLinkRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(filelinks)/\(link)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(filelinks)/\(link)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
-    public func listAll(filter: [String: Any]?), context: LoggingContext -> EventLoopFuture<StripeFileLinkList> {
+    public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeFileLinkList> {
         var queryParams = ""
         if let filter = filter {
             queryParams = filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: filelinks, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: filelinks, query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Core Resources/File Links/FileLinkRoutes.swift
+++ b/Sources/StripeKit/Core Resources/File Links/FileLinkRoutes.swift
@@ -8,6 +8,7 @@
 import NIO
 import NIOHTTP1
 import Foundation
+import Baggage
 
 public protocol FileLinkRoutes {
     /// Creates a new file link object.
@@ -21,7 +22,8 @@ public protocol FileLinkRoutes {
     func create(file: String,
                 expiresAt: Date?,
                 metadata: [String: String]?,
-                expand: [String]?) -> EventLoopFuture<StripeFileLink>
+                expand: [String]?,
+                context: LoggingContext) -> EventLoopFuture<StripeFileLink>
     
     /// Retrieves the file link with the given ID.
     ///
@@ -29,7 +31,7 @@ public protocol FileLinkRoutes {
     ///   - link: The identifier of the file link to be retrieved.
     ///   - expand: An array of properties to expand.
     /// - Returns: A `StripeFileLink`.
-    func retrieve(link: String, expand: [String]?) -> EventLoopFuture<StripeFileLink>
+    func retrieve(link: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeFileLink>
     
     /// Updates an existing file link object. Expired links can no longer be updated
     ///
@@ -42,14 +44,15 @@ public protocol FileLinkRoutes {
     func update(link: String,
                 expiresAt: Any?,
                 metadata: [String: String]?,
-                expand: [String]?) -> EventLoopFuture<StripeFileLink>
+                expand: [String]?,
+                context: LoggingContext) -> EventLoopFuture<StripeFileLink>
     
     
     /// Returns a list of file links.
     ///
     /// - Parameter filter: A dictionary that contains the filters. More info [here](https://stripe.com/docs/api/curl#list_file_links).
     /// - Returns: A `StripeFileLinkList`.
-    func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeFileLinkList>
+    func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeFileLinkList>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
@@ -59,28 +62,30 @@ extension FileLinkRoutes {
     public func create(file: String,
                        expiresAt: Date? = nil,
                        metadata: [String: String]? = nil,
-                       expand: [String]? = nil) -> EventLoopFuture<StripeFileLink> {
+                       expand: [String]? = nil,
+                       context: LoggingContext) -> EventLoopFuture<StripeFileLink> {
         return create(file: file,
                       expiresAt: expiresAt,
                       metadata: metadata,
                       expand: expand)
     }
     
-    public func retrieve(link: String, expand: [String]? = nil) -> EventLoopFuture<StripeFileLink> {
+    public func retrieve(link: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeFileLink> {
         return retrieve(link: link, expand: expand)
     }
     
     public func update(link: String,
                        expiresAt: Any? = nil,
                        metadata: [String: String]? = nil,
-                       expand: [String]? = nil) -> EventLoopFuture<StripeFileLink> {
+                       expand: [String]? = nil,
+                       context: LoggingContext) -> EventLoopFuture<StripeFileLink> {
         return update(link: link,
                       expiresAt: expiresAt,
                       metadata: metadata,
                       expand: expand)
     }
     
-    public func listAll(filter: [String: Any]? = nil) -> EventLoopFuture<StripeFileLinkList> {
+    public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeFileLinkList> {
         return listAll(filter: filter)
     }
 }
@@ -98,7 +103,8 @@ public struct StripeFileLinkRoutes: FileLinkRoutes {
     public func create(file: String,
                        expiresAt: Date?,
                        metadata: [String: String]?,
-                       expand: [String]?) -> EventLoopFuture<StripeFileLink> {
+                       expand: [String]?,
+                       context: LoggingContext) -> EventLoopFuture<StripeFileLink> {
         var body: [String: Any] = [:]
         if let expiresAt = expiresAt {
             body["expires_at"] = Int(expiresAt.timeIntervalSince1970)
@@ -115,7 +121,7 @@ public struct StripeFileLinkRoutes: FileLinkRoutes {
         return apiHandler.send(method: .POST, path: filelinks, body: .string(body.queryParameters), headers: headers)
     }
     
-    public func retrieve(link: String, expand: [String]?) -> EventLoopFuture<StripeFileLink> {
+    public func retrieve(link: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeFileLink> {
         var queryParams = ""
         if let expand = expand {
             queryParams = ["expand": expand].queryParameters
@@ -127,7 +133,8 @@ public struct StripeFileLinkRoutes: FileLinkRoutes {
     public func update(link: String,
                        expiresAt: Any?,
                        metadata: [String: String]?,
-                       expand: [String]?) -> EventLoopFuture<StripeFileLink> {
+                       expand: [String]?,
+                       context: LoggingContext) -> EventLoopFuture<StripeFileLink> {
         var body: [String: Any] = [:]
         
         if let expiresAt = expiresAt as? Date {
@@ -149,7 +156,7 @@ public struct StripeFileLinkRoutes: FileLinkRoutes {
         return apiHandler.send(method: .POST, path: "\(filelinks)/\(link)", body: .string(body.queryParameters), headers: headers)
     }
     
-    public func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeFileLinkList> {
+    public func listAll(filter: [String: Any]?), context: LoggingContext -> EventLoopFuture<StripeFileLinkList> {
         var queryParams = ""
         if let filter = filter {
             queryParams = filter.queryParameters

--- a/Sources/StripeKit/Core Resources/Files/FileRoutes.swift
+++ b/Sources/StripeKit/Core Resources/Files/FileRoutes.swift
@@ -38,15 +38,15 @@ public protocol FileRoutes {
 
 extension FileRoutes {
     public mutating func create(file: Data, purpose: StripeFilePurpose, fileLinkData: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeFile> {
-        return create(file: file, purpose: purpose, fileLinkData: fileLinkData)
+        return create(file: file, purpose: purpose, fileLinkData: fileLinkData, context: context)
     }
     
     public func retrieve(file: String, context: LoggingContext) -> EventLoopFuture<StripeFile> {
-        return retrieve(file: file)
+        return retrieve(file: file, context: context)
     }
     
     public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeFileUploadList> {
-        return listAll(filter: filter)
+        return listAll(filter: filter, context: context)
     }
 }
 
@@ -88,11 +88,11 @@ public struct StripeFileRoutes: FileRoutes {
         
         body.append("\r\n--\(boundary)--\r\n")
         
-        return apiHandler.send(method: .POST, path: filesupload, body: .data(body), headers: headers)
+        return apiHandler.send(method: .POST, path: filesupload, body: .data(body), headers: headers, context: context)
     }
     
     public func retrieve(file: String, context: LoggingContext) -> EventLoopFuture<StripeFile> {
-        return apiHandler.send(method: .GET, path: "\(files)/\(file)", headers: headers)
+        return apiHandler.send(method: .GET, path: "\(files)/\(file)", headers: headers, context: context)
     }
     
     public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeFileUploadList> {
@@ -101,7 +101,7 @@ public struct StripeFileRoutes: FileRoutes {
             queryParams = filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: files, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: files, query: queryParams, headers: headers, context: context)
     }
 }
 

--- a/Sources/StripeKit/Core Resources/Mandates/MandateRoutes.swift
+++ b/Sources/StripeKit/Core Resources/Mandates/MandateRoutes.swift
@@ -22,7 +22,7 @@ public protocol MandateRoutes {
 
 extension MandateRoutes {
     func retrieve(mandate: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeMandate> {
-        return retrieve(mandate: mandate, expand: expand)
+        return retrieve(mandate: mandate, expand: expand, context: context)
     }
 }
 
@@ -42,6 +42,6 @@ public struct StripeMandateRoutes: MandateRoutes {
             queryParams = ["expand": expand].queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: "\(self.mandate)/\(mandate)", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(self.mandate)/\(mandate)", query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Core Resources/Mandates/MandateRoutes.swift
+++ b/Sources/StripeKit/Core Resources/Mandates/MandateRoutes.swift
@@ -7,20 +7,21 @@
 
 import NIO
 import NIOHTTP1
+import Baggage
 
 public protocol MandateRoutes {
     
     /// Retrieves a Mandate object
     /// - Parameter mandate: ID of the Mandate to retrieve.
     /// - Parameter expand: An array of porperties to expand.
-    func retrieve(mandate: String, expand: [String]?) -> EventLoopFuture<StripeMandate>
+    func retrieve(mandate: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeMandate>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
 }
 
 extension MandateRoutes {
-    func retrieve(mandate: String, expand: [String]? = nil) -> EventLoopFuture<StripeMandate> {
+    func retrieve(mandate: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeMandate> {
         return retrieve(mandate: mandate, expand: expand)
     }
 }
@@ -35,7 +36,7 @@ public struct StripeMandateRoutes: MandateRoutes {
         self.apiHandler = apiHandler
     }
     
-    public func retrieve(mandate: String, expand: [String]?) -> EventLoopFuture<StripeMandate> {
+    public func retrieve(mandate: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeMandate> {
         var queryParams = ""
         if let expand = expand {
             queryParams = ["expand": expand].queryParameters

--- a/Sources/StripeKit/Core Resources/PaymentIntents/PaymentIntentsRoutes.swift
+++ b/Sources/StripeKit/Core Resources/PaymentIntents/PaymentIntentsRoutes.swift
@@ -7,6 +7,7 @@
 
 import NIO
 import NIOHTTP1
+import Baggage
 
 public protocol PaymentIntentsRoutes {
     /// Creates a PaymentIntent object.
@@ -68,14 +69,15 @@ public protocol PaymentIntentsRoutes {
                 transferData: [String: Any]?,
                 transferGroup: String?,
                 useStripeSDK: Bool?,
-                expand: [String]?) -> EventLoopFuture<StripePaymentIntent>
+                expand: [String]?,
+                context: LoggingContext) -> EventLoopFuture<StripePaymentIntent>
     
     /// Retrieves the details of a PaymentIntent that has previously been created.
     ///
     /// - Parameter id: The identifier of the paymentintent to be retrieved.
     /// - Parameter clientSecret: The client secret to use if required.
     /// - Returns: A `StripePaymentIntent`.
-    func retrieve(intent: String, clientSecret: String?) -> EventLoopFuture<StripePaymentIntent>
+    func retrieve(intent: String, clientSecret: String?, context: LoggingContext) -> EventLoopFuture<StripePaymentIntent>
     
     /// Updates a PaymentIntent object.
     ///
@@ -117,7 +119,8 @@ public protocol PaymentIntentsRoutes {
                 statementDescriptorSuffix: String?,
                 transferData: [String: Any]?,
                 transferGroup: String?,
-                expand: [String]?) -> EventLoopFuture<StripePaymentIntent>
+                expand: [String]?,
+                context: LoggingContext) -> EventLoopFuture<StripePaymentIntent>
     
     /// Confirm that your customer intends to pay with current or provided payment method. Upon confirmation, the PaymentIntent will attempt to initiate a payment. /n If the selected payment method requires additional authentication steps, the PaymentIntent will transition to the `requires_action` status and suggest additional actions via `next_action`. If payment fails, the PaymentIntent will transition to the `requires_payment_method` status. If payment succeeds, the PaymentIntent will transition to the `succeeded` status (or `requires_capture`, if `capture_method` is set to `manual`). /n If the `confirmation_method` is `automatic`, payment may be attempted using our client SDKs and the PaymentIntent’s `client_secret`. After `next_action`s are handled by the client, no additional confirmation is required to complete the payment. /n If the `confirmation_method` is `manual`, all payment attempts must be initiated using a secret key. If any actions are required for the payment, the PaymentIntent will return to the `requires_confirmation` state after those actions are completed. Your server needs to then explicitly re-confirm the PaymentIntent to initiate the next payment attempt. Read the expanded documentation to learn more about manual confirmation.
     ///
@@ -152,7 +155,8 @@ public protocol PaymentIntentsRoutes {
                  setupFutureUsage: StripePaymentIntentSetupFutureUsage?,
                  shipping: [String: Any]?,
                  useStripeSDK: Bool?,
-                 expand: [String]?) -> EventLoopFuture<StripePaymentIntent>
+                 expand: [String]?,
+                 context: LoggingContext) -> EventLoopFuture<StripePaymentIntent>
     
     /// Capture the funds of an existing uncaptured PaymentIntent when its status is `requires_capture`. /n Uncaptured PaymentIntents will be canceled exactly seven days after they are created. /n Read the expanded documentation to learn more about separate authorization and capture.
     ///
@@ -171,7 +175,8 @@ public protocol PaymentIntentsRoutes {
                  statementDescriptor: String?,
                  statementDescriptorSuffix: String?,
                  transferData: [String: Any]?,
-                 expand: [String]?) -> EventLoopFuture<StripePaymentIntent>
+                 expand: [String]?,
+                 context: LoggingContext) -> EventLoopFuture<StripePaymentIntent>
     
     ///  PaymentIntent object can be canceled when it is in one of these statuses: `requires_payment_method`, `requires_capture`, `requires_confirmation`, `requires_action`. /n Once canceled, no additional charges will be made by the PaymentIntent and any operations on the PaymentIntent will fail with an error. For PaymentIntents with `status='requires_capture'`, the remaining `amount_capturable` will automatically be refunded.
 
@@ -181,13 +186,14 @@ public protocol PaymentIntentsRoutes {
     ///   - expand: An array of properties to expand.
     func cancel(intent: String,
                 cancellationReason: StripePaymentIntentCancellationReason?,
-                expand: [String]?) -> EventLoopFuture<StripePaymentIntent>
+                expand: [String]?,
+                context: LoggingContext) -> EventLoopFuture<StripePaymentIntent>
     
     /// Returns a list of PaymentIntents.
     ///
     /// - Parameter filter: A dictionary that contains the filters. More info [here](https://stripe.com/docs/api/payment_intents/list).
     /// - Returns: A `StripePaymentIntentsList`.
-    func listAll(filter: [String: Any]?) -> EventLoopFuture<StripePaymentIntentsList>
+    func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripePaymentIntentsList>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
@@ -221,7 +227,8 @@ extension PaymentIntentsRoutes {
                        transferData: [String: Any]? = nil,
                        transferGroup: String? = nil,
                        useStripeSDK: Bool? = nil,
-                       expand: [String]? = nil) -> EventLoopFuture<StripePaymentIntent> {
+                       expand: [String]? = nil,
+                       context: LoggingContext) -> EventLoopFuture<StripePaymentIntent> {
         return create(amount: amount,
                       currency: currency,
                       applicationFeeAmount: applicationFeeAmount,
@@ -252,7 +259,7 @@ extension PaymentIntentsRoutes {
                       expand: expand)
     }
     
-    public func retrieve(intent: String, clientSecret: String? = nil) -> EventLoopFuture<StripePaymentIntent> {
+    public func retrieve(intent: String, clientSecret: String? = nil, context: LoggingContext) -> EventLoopFuture<StripePaymentIntent> {
         return retrieve(intent: intent, clientSecret: clientSecret)
     }
     
@@ -273,7 +280,8 @@ extension PaymentIntentsRoutes {
                        statementDescriptorSuffix: String? = nil,
                        transferData: [String: Any]? = nil,
                        transferGroup: String? = nil,
-                       expand: [String]? = nil) -> EventLoopFuture<StripePaymentIntent> {
+                       expand: [String]? = nil,
+                       context: LoggingContext) -> EventLoopFuture<StripePaymentIntent> {
         return update(intent: intent,
                       amount: amount,
                       applicationFeeAmount: applicationFeeAmount,
@@ -308,7 +316,8 @@ extension PaymentIntentsRoutes {
                         setupFutureUsage: StripePaymentIntentSetupFutureUsage? = nil,
                         shipping: [String: Any]? = nil,
                         useStripeSDK: Bool? = nil,
-                        expand: [String]? = nil) -> EventLoopFuture<StripePaymentIntent> {
+                        expand: [String]? = nil,
+                        context: LoggingContext) -> EventLoopFuture<StripePaymentIntent> {
         return confirm(intent: intent,
                        errorOnRequiresAction: errorOnRequiresAction,
                        mandate: mandate,
@@ -332,7 +341,8 @@ extension PaymentIntentsRoutes {
                         statementDescriptor: String? = nil,
                         statementDescriptorSuffix: String? = nil,
                         transferData: [String: Any]? = nil,
-                        expand: [String]? = nil) -> EventLoopFuture<StripePaymentIntent> {
+                        expand: [String]? = nil,
+                        context: LoggingContext) -> EventLoopFuture<StripePaymentIntent> {
         return capture(intent: intent,
                        amountToCapture: amountToCapture,
                        applicationFeeAmount: applicationFeeAmount,
@@ -344,11 +354,12 @@ extension PaymentIntentsRoutes {
     
     public func cancel(intent: String,
                        cancellationReason: StripePaymentIntentCancellationReason? = nil,
-                       expand: [String]? = nil) -> EventLoopFuture<StripePaymentIntent> {
+                       expand: [String]? = nil,
+                       context: LoggingContext) -> EventLoopFuture<StripePaymentIntent> {
         return cancel(intent: intent, cancellationReason: cancellationReason, expand: expand)
     }
     
-    public func listAll(filter: [String: Any]? = nil) -> EventLoopFuture<StripePaymentIntentsList> {
+    public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripePaymentIntentsList> {
         return listAll(filter: filter)
     }
 }
@@ -390,7 +401,8 @@ public struct StripePaymentIntentsRoutes: PaymentIntentsRoutes {
                        transferData: [String: Any]?,
                        transferGroup: String?,
                        useStripeSDK: Bool?,
-                       expand: [String]?) -> EventLoopFuture<StripePaymentIntent> {
+                       expand: [String]?,
+                       context: LoggingContext) -> EventLoopFuture<StripePaymentIntent> {
         var body: [String: Any] = ["amount": amount,
                                    "currency": currency.rawValue]
         
@@ -501,7 +513,7 @@ public struct StripePaymentIntentsRoutes: PaymentIntentsRoutes {
         return apiHandler.send(method: .POST, path: paymentintents, body: .string(body.queryParameters), headers: headers)
     }
     
-    public func retrieve(intent: String, clientSecret: String?) -> EventLoopFuture<StripePaymentIntent> {
+    public func retrieve(intent: String, clientSecret: String?, context: LoggingContext) -> EventLoopFuture<StripePaymentIntent> {
         var query = ""
         if let clientSecret = clientSecret {
             query += "client_secret=\(clientSecret)"
@@ -526,7 +538,8 @@ public struct StripePaymentIntentsRoutes: PaymentIntentsRoutes {
                        statementDescriptorSuffix: String?,
                        transferData: [String: Any]?,
                        transferGroup: String?,
-                       expand: [String]?) -> EventLoopFuture<StripePaymentIntent> {
+                       expand: [String]?,
+                       context: LoggingContext) -> EventLoopFuture<StripePaymentIntent> {
         var body: [String: Any] = [:]
         
         if let amount = amount {
@@ -614,7 +627,8 @@ public struct StripePaymentIntentsRoutes: PaymentIntentsRoutes {
                         setupFutureUsage: StripePaymentIntentSetupFutureUsage?,
                         shipping: [String: Any]?,
                         useStripeSDK: Bool?,
-                        expand: [String]?) -> EventLoopFuture<StripePaymentIntent> {
+                        expand: [String]?,
+                        context: LoggingContext) -> EventLoopFuture<StripePaymentIntent> {
         var body: [String: Any] = [:]
         
         if let errorOnRequiresAction = errorOnRequiresAction {
@@ -682,7 +696,8 @@ public struct StripePaymentIntentsRoutes: PaymentIntentsRoutes {
                         statementDescriptor: String?,
                         statementDescriptorSuffix: String?,
                         transferData: [String: Any]?,
-                        expand: [String]?) -> EventLoopFuture<StripePaymentIntent> {
+                        expand: [String]?,
+                        context: LoggingContext) -> EventLoopFuture<StripePaymentIntent> {
         var body: [String: Any] = [:]
         
         if let amountToCapture = amountToCapture {
@@ -712,7 +727,7 @@ public struct StripePaymentIntentsRoutes: PaymentIntentsRoutes {
         return apiHandler.send(method: .POST, path: "\(paymentintents)/\(intent)/capture", body: .string(body.queryParameters), headers: headers)
     }
     
-    public func cancel(intent: String, cancellationReason: StripePaymentIntentCancellationReason?, expand: [String]?) -> EventLoopFuture<StripePaymentIntent> {
+    public func cancel(intent: String, cancellationReason: StripePaymentIntentCancellationReason?, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripePaymentIntent> {
         var body: [String: Any] = [:]
         
         if let cancellationReason = cancellationReason {
@@ -726,7 +741,7 @@ public struct StripePaymentIntentsRoutes: PaymentIntentsRoutes {
         return apiHandler.send(method: .POST, path: "\(paymentintents)/\(intent)/cancel", body: .string(body.queryParameters), headers: headers)
     }
     
-    public func listAll(filter: [String: Any]?) -> EventLoopFuture<StripePaymentIntentsList> {
+    public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripePaymentIntentsList> {
         var queryParams = ""
         if let filter = filter {
             queryParams = filter.queryParameters

--- a/Sources/StripeKit/Core Resources/PaymentIntents/PaymentIntentsRoutes.swift
+++ b/Sources/StripeKit/Core Resources/PaymentIntents/PaymentIntentsRoutes.swift
@@ -256,11 +256,12 @@ extension PaymentIntentsRoutes {
                       transferData: transferData,
                       transferGroup: transferGroup,
                       useStripeSDK: useStripeSDK,
-                      expand: expand)
+                      expand: expand,
+                      context: context)
     }
     
     public func retrieve(intent: String, clientSecret: String? = nil, context: LoggingContext) -> EventLoopFuture<StripePaymentIntent> {
-        return retrieve(intent: intent, clientSecret: clientSecret)
+        return retrieve(intent: intent, clientSecret: clientSecret, context: context)
     }
     
     public func update(intent: String,
@@ -299,7 +300,8 @@ extension PaymentIntentsRoutes {
                       statementDescriptorSuffix: statementDescriptorSuffix,
                       transferData: transferData,
                       transferGroup: transferGroup,
-                      expand: expand)
+                      expand: expand,
+                      context: context)
     }
     
     public func confirm(intent: String,
@@ -332,7 +334,8 @@ extension PaymentIntentsRoutes {
                        setupFutureUsage: setupFutureUsage,
                        shipping: shipping,
                        useStripeSDK: useStripeSDK,
-                       expand: expand)
+                       expand: expand,
+                       context: context)
     }
     
     public func capture(intent: String,
@@ -349,18 +352,19 @@ extension PaymentIntentsRoutes {
                        statementDescriptor: statementDescriptor,
                        statementDescriptorSuffix: statementDescriptorSuffix,
                        transferData: transferData,
-                       expand: expand)
+                       expand: expand,
+                       context: context)
     }
     
     public func cancel(intent: String,
                        cancellationReason: StripePaymentIntentCancellationReason? = nil,
                        expand: [String]? = nil,
                        context: LoggingContext) -> EventLoopFuture<StripePaymentIntent> {
-        return cancel(intent: intent, cancellationReason: cancellationReason, expand: expand)
+        return cancel(intent: intent, cancellationReason: cancellationReason, expand: expand, context: context)
     }
     
     public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripePaymentIntentsList> {
-        return listAll(filter: filter)
+        return listAll(filter: filter, context: context)
     }
 }
 
@@ -510,7 +514,7 @@ public struct StripePaymentIntentsRoutes: PaymentIntentsRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: paymentintents, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: paymentintents, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(intent: String, clientSecret: String?, context: LoggingContext) -> EventLoopFuture<StripePaymentIntent> {
@@ -518,7 +522,7 @@ public struct StripePaymentIntentsRoutes: PaymentIntentsRoutes {
         if let clientSecret = clientSecret {
             query += "client_secret=\(clientSecret)"
         }
-        return apiHandler.send(method: .GET, path: "\(paymentintents)/\(intent)", query: query)
+        return apiHandler.send(method: .GET, path: "\(paymentintents)/\(intent)", query: query, context: context)
     }
     
     public func update(intent: String,
@@ -610,7 +614,7 @@ public struct StripePaymentIntentsRoutes: PaymentIntentsRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(paymentintents)/\(intent)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(paymentintents)/\(intent)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func confirm(intent: String,
@@ -687,7 +691,7 @@ public struct StripePaymentIntentsRoutes: PaymentIntentsRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(paymentintents)/\(intent)/confirm", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(paymentintents)/\(intent)/confirm", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func capture(intent: String,
@@ -724,7 +728,7 @@ public struct StripePaymentIntentsRoutes: PaymentIntentsRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(paymentintents)/\(intent)/capture", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(paymentintents)/\(intent)/capture", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func cancel(intent: String, cancellationReason: StripePaymentIntentCancellationReason?, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripePaymentIntent> {
@@ -738,7 +742,7 @@ public struct StripePaymentIntentsRoutes: PaymentIntentsRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(paymentintents)/\(intent)/cancel", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(paymentintents)/\(intent)/cancel", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripePaymentIntentsList> {
@@ -747,6 +751,6 @@ public struct StripePaymentIntentsRoutes: PaymentIntentsRoutes {
             queryParams = filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: paymentintents, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: paymentintents, query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Core Resources/Payouts/PayoutRoutes.swift
+++ b/Sources/StripeKit/Core Resources/Payouts/PayoutRoutes.swift
@@ -92,27 +92,28 @@ extension PayoutRoutes {
                       method: method,
                       sourceType: sourceType,
                       statementDescriptor: statementDescriptor,
-                      expand: expand)
+                      expand: expand,
+                      context: context)
     }
     
     public func retrieve(payout: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripePayout> {
-        return retrieve(payout: payout, expand: expand)
+        return retrieve(payout: payout, expand: expand, context: context)
     }
     
     public func update(payout: String, metadata: [String: String]? = nil, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripePayout> {
-        return update(payout: payout, metadata: metadata, expand: expand)
+        return update(payout: payout, metadata: metadata, expand: expand, context: context)
     }
     
     public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripePayoutsList> {
-        return listAll(filter: filter)
+        return listAll(filter: filter, context: context)
     }
     
     public func cancel(payout: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripePayout> {
-        return cancel(payout: payout, expand: expand)
+        return cancel(payout: payout, expand: expand, context: context)
     }
     
     public func reverse(payout: String, metadata: [String: String]? = nil, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripePayout> {
-        return reverse(payout: payout, metadata: metadata, expand: expand)
+        return reverse(payout: payout, metadata: metadata, expand: expand, context: context)
     }
 }
 
@@ -169,7 +170,7 @@ public struct StripePayoutRoutes: PayoutRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: payouts, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: payouts, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(payout: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripePayout> {
@@ -178,7 +179,7 @@ public struct StripePayoutRoutes: PayoutRoutes {
             queryParams = ["expand": expand].queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: "\(payouts)/\(payout)", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(payouts)/\(payout)", query: queryParams, headers: headers, context: context)
     }
     
     public func update(payout: String, metadata: [String: String]?, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripePayout> {
@@ -191,7 +192,7 @@ public struct StripePayoutRoutes: PayoutRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(payouts)/\(payout)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(payouts)/\(payout)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripePayoutsList> {
@@ -200,7 +201,7 @@ public struct StripePayoutRoutes: PayoutRoutes {
             queryParams = filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: payouts, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: payouts, query: queryParams, headers: headers, context: context)
     }
     
     public func cancel(payout: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripePayout> {
@@ -210,7 +211,7 @@ public struct StripePayoutRoutes: PayoutRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(payouts)/\(payout)/cancel", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(payouts)/\(payout)/cancel", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func reverse(payout: String, metadata: [String: String]?, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripePayout> {
@@ -224,6 +225,6 @@ public struct StripePayoutRoutes: PayoutRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(payouts)/\(payout)/reverse", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(payouts)/\(payout)/reverse", body: .string(body.queryParameters), headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Core Resources/Prices/PriceRoutes.swift
+++ b/Sources/StripeKit/Core Resources/Prices/PriceRoutes.swift
@@ -111,11 +111,12 @@ extension PriceRoutes {
                transferLookupKey: transferLookupKey,
                transformQuantity: transformQuantity,
                unitAmountDecimal: unitAmountDecimal,
-               expand: expand)
+               expand: expand,
+               context: context)
     }
     
     public func retrieve(price: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripePrice> {
-        retrieve(price: price, expand: expand)
+        retrieve(price: price, expand: expand, context: context)
     }
     
     public func update(price: String,
@@ -132,11 +133,12 @@ extension PriceRoutes {
                nickname: nickname,
                lookupKey: lookupKey,
                transferLookupKey: transferLookupKey,
-               expand: expand)
+               expand: expand,
+               context: context)
     }
     
     public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripePriceList> {
-        listAll(filter: filter)
+        listAll(filter: filter, context: context)
     }
 }
 
@@ -231,7 +233,7 @@ public struct StripePriceRoutes: PriceRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: prices, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: prices, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(price: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripePrice> {
@@ -240,7 +242,7 @@ public struct StripePriceRoutes: PriceRoutes {
             queryParams = ["expand": expand].queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: "\(prices)/\(price)", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(prices)/\(price)", query: queryParams, headers: headers, context: context)
     }
     
     public func update(price: String,
@@ -274,7 +276,7 @@ public struct StripePriceRoutes: PriceRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(prices)/\(price)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(prices)/\(price)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripePriceList> {
@@ -283,6 +285,6 @@ public struct StripePriceRoutes: PriceRoutes {
             queryParams = filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: prices, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: prices, query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Core Resources/Prices/PriceRoutes.swift
+++ b/Sources/StripeKit/Core Resources/Prices/PriceRoutes.swift
@@ -8,6 +8,7 @@
 import NIO
 import NIOHTTP1
 import Foundation
+import Baggage
 
 public protocol PriceRoutes {
     /// Creates a new price for an existing product. The price can be recurring or one-time.
@@ -43,12 +44,13 @@ public protocol PriceRoutes {
                 transferLookupKey: String?,
                 transformQuantity: [String: Any]?,
                 unitAmountDecimal: Decimal?,
-                expand: [String]?) -> EventLoopFuture<StripePrice>
+                expand: [String]?,
+                context: LoggingContext) -> EventLoopFuture<StripePrice>
     
     /// Retrieves the price with the given ID.
     /// - Parameter price: The ID of the price to retrieve.
     /// - Parameter expand: An array of properties to expand.
-    func retrieve(price: String, expand: [String]?) -> EventLoopFuture<StripePrice>
+    func retrieve(price: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripePrice>
     
     /// Updates the specified price by setting the values of the parameters passed. Any parameters not provided are left unchanged.
     /// - Parameters:
@@ -65,11 +67,12 @@ public protocol PriceRoutes {
                 nickname: String?,
                 lookupKey: String?,
                 transferLookupKey: String?,
-                expand: [String]?) -> EventLoopFuture<StripePrice>
+                expand: [String]?,
+                context: LoggingContext) -> EventLoopFuture<StripePrice>
     
     /// Returns a list of your prices.
     /// - Parameter filter: A dictionary that will be used for the query parameters.
-    func listAll(filter: [String: Any]?) -> EventLoopFuture<StripePriceList>
+    func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripePriceList>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
@@ -91,7 +94,8 @@ extension PriceRoutes {
                        transferLookupKey: String? = nil,
                        transformQuantity: [String: Any]? = nil,
                        unitAmountDecimal: Decimal? = nil,
-                       expand: [String]? = nil) -> EventLoopFuture<StripePrice> {
+                       expand: [String]? = nil,
+                       context: LoggingContext) -> EventLoopFuture<StripePrice> {
         create(currency: currency,
                unitAmount: unitAmount,
                active: active,
@@ -110,7 +114,7 @@ extension PriceRoutes {
                expand: expand)
     }
     
-    public func retrieve(price: String, expand: [String]? = nil) -> EventLoopFuture<StripePrice> {
+    public func retrieve(price: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripePrice> {
         retrieve(price: price, expand: expand)
     }
     
@@ -120,7 +124,8 @@ extension PriceRoutes {
                        nickname: String? = nil,
                        lookupKey: String? = nil,
                        transferLookupKey: String? = nil,
-                       expand: [String]? = nil) -> EventLoopFuture<StripePrice> {
+                       expand: [String]? = nil,
+                       context: LoggingContext) -> EventLoopFuture<StripePrice> {
         update(price: price,
                active: active,
                metadata: metadata,
@@ -130,7 +135,7 @@ extension PriceRoutes {
                expand: expand)
     }
     
-    public func listAll(filter: [String: Any]? = nil) -> EventLoopFuture<StripePriceList> {
+    public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripePriceList> {
         listAll(filter: filter)
     }
 }
@@ -160,7 +165,8 @@ public struct StripePriceRoutes: PriceRoutes {
                        transferLookupKey: String?,
                        transformQuantity: [String: Any]?,
                        unitAmountDecimal: Decimal?,
-                       expand: [String]?) -> EventLoopFuture<StripePrice> {
+                       expand: [String]?,
+                       context: LoggingContext) -> EventLoopFuture<StripePrice> {
         var body: [String: Any] = [:]
         
         body["currency"] = currency.rawValue
@@ -228,7 +234,7 @@ public struct StripePriceRoutes: PriceRoutes {
         return apiHandler.send(method: .POST, path: prices, body: .string(body.queryParameters), headers: headers)
     }
     
-    public func retrieve(price: String, expand: [String]?) -> EventLoopFuture<StripePrice> {
+    public func retrieve(price: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripePrice> {
         var queryParams = ""
         if let expand = expand {
             queryParams = ["expand": expand].queryParameters
@@ -243,7 +249,8 @@ public struct StripePriceRoutes: PriceRoutes {
                        nickname: String?,
                        lookupKey: String?,
                        transferLookupKey: String?,
-                       expand: [String]?) -> EventLoopFuture<StripePrice> {
+                       expand: [String]?,
+                       context: LoggingContext) -> EventLoopFuture<StripePrice> {
         
         var body: [String: Any] = [:]
         
@@ -270,7 +277,7 @@ public struct StripePriceRoutes: PriceRoutes {
         return apiHandler.send(method: .POST, path: "\(prices)/\(price)", body: .string(body.queryParameters), headers: headers)
     }
     
-    public func listAll(filter: [String: Any]?) -> EventLoopFuture<StripePriceList> {
+    public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripePriceList> {
         var queryParams = ""
         if let filter = filter {
             queryParams = filter.queryParameters

--- a/Sources/StripeKit/Core Resources/Products/ProductRoutes.swift
+++ b/Sources/StripeKit/Core Resources/Products/ProductRoutes.swift
@@ -126,11 +126,12 @@ extension ProductRoutes {
                       packageDimensions: packageDimensions,
                       shippable: shippable,
                       type: type,
-                      url: url)
+                      url: url,
+                      context: context)
     }
     
     public func retrieve(id: String, context: LoggingContext) -> EventLoopFuture<StripeProduct> {
-        return retrieve(id: id)
+        return retrieve(id: id, context: context)
     }
     
     public func update(product: String,
@@ -149,27 +150,28 @@ extension ProductRoutes {
                        url: String? = nil,
                        context: LoggingContext) -> EventLoopFuture<StripeProduct> {
         return update(product: product,
-                          active: active,
-                          attributes: attributes,
-                          caption: caption,
-                          deactivateOn: deactivateOn,
-                          description: description,
-                          images: images,
-                          metadata: metadata,
-                          name: name,
-                          packageDimensions: packageDimensions,
-                          shippable: shippable,
-                          statementDescriptor: statementDescriptor,
-                          unitLabel: unitLabel,
-                          url: url)
+                      active: active,
+                      attributes: attributes,
+                      caption: caption,
+                      deactivateOn: deactivateOn,
+                      description: description,
+                      images: images,
+                      metadata: metadata,
+                      name: name,
+                      packageDimensions: packageDimensions,
+                      shippable: shippable,
+                      statementDescriptor: statementDescriptor,
+                      unitLabel: unitLabel,
+                      url: url,
+                      context: context)
     }
     
     public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeProductsList> {
-        return listAll(filter: filter)
+        return listAll(filter: filter, context: context)
     }
     
     public func delete(id: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
-        return delete(id: id)
+        return delete(id: id, context: context)
     }
 }
 
@@ -249,11 +251,11 @@ public struct StripeProductRoutes: ProductRoutes {
             body["url"] = url
         }
         
-        return apiHandler.send(method: .POST, path: products, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: products, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(id: String, context: LoggingContext) -> EventLoopFuture<StripeProduct> {
-        return apiHandler.send(method: .GET, path: "\(products)/\(id)", headers: headers)
+        return apiHandler.send(method: .GET, path: "\(products)/\(id)", headers: headers, context: context)
     }
     
     public func update(product: String,
@@ -326,7 +328,7 @@ public struct StripeProductRoutes: ProductRoutes {
             body["url"] = url
         }
 
-        return apiHandler.send(method: .POST, path: "\(products)/\(product)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(products)/\(product)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeProductsList> {
@@ -335,10 +337,10 @@ public struct StripeProductRoutes: ProductRoutes {
             queryParams = filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: products, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: products, query: queryParams, headers: headers, context: context)
     }
     
     public func delete(id: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
-        return apiHandler.send(method: .DELETE, path: "\(products)/\(id)", headers: headers)
+        return apiHandler.send(method: .DELETE, path: "\(products)/\(id)", headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Core Resources/Refunds/RefundRoutes.swift
+++ b/Sources/StripeKit/Core Resources/Refunds/RefundRoutes.swift
@@ -77,22 +77,23 @@ extension RefundRoutes {
                       reason: reason,
                       refundApplicationFee: refundApplicationFee,
                       reverseTransfer: reverseTransfer,
-                      expand: expand)
+                      expand: expand,
+                      context: context)
     }
     
     public func retrieve(refund: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeRefund> {
-        return retrieve(refund: refund, expand: expand)
+        return retrieve(refund: refund, expand: expand, context: context)
     }
     
     public func update(refund: String,
                        metadata: [String: String]? = nil,
                        expand: [String]? = nil,
                        context: LoggingContext) -> EventLoopFuture<StripeRefund> {
-        return update(refund: refund, metadata: metadata, expand: expand)
+        return update(refund: refund, metadata: metadata, expand: expand, context: context)
     }
     
     public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeRefundsList> {
-        return listAll(filter: filter)
+        return listAll(filter: filter, context: context)
     }
 }
 
@@ -149,7 +150,7 @@ public struct StripeRefundRoutes: RefundRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: refunds, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: refunds, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(refund: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeRefund> {
@@ -158,7 +159,7 @@ public struct StripeRefundRoutes: RefundRoutes {
             queryParams = ["expand": expand].queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: "\(refunds)/\(refund)", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(refunds)/\(refund)", query: queryParams, headers: headers, context: context)
     }
     
     public func update(refund: String, metadata: [String: String]?, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeRefund> {
@@ -172,7 +173,7 @@ public struct StripeRefundRoutes: RefundRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(refunds)/\(refund)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(refunds)/\(refund)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeRefundsList> {
@@ -181,6 +182,6 @@ public struct StripeRefundRoutes: RefundRoutes {
             queryParams = filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: refunds, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: refunds, query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Core Resources/SetupAttempt/SetupAttemptRoutes.swift
+++ b/Sources/StripeKit/Core Resources/SetupAttempt/SetupAttemptRoutes.swift
@@ -18,7 +18,7 @@ public protocol SetupAttemptRoutes {
 
 extension SetupAttemptRoutes {
     public func listAll(setupIntent: String, filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeSetupAttemptList> {
-        listAll(setupIntent: setupIntent, filter: filter)
+        listAll(setupIntent: setupIntent, filter: filter, context: context)
     }
 }
 
@@ -37,6 +37,6 @@ public struct StripeSetupAttemptRoutes: SetupAttemptRoutes {
         if let filter = filter {
             queryParams = filter.queryParameters
         }
-        return apiHandler.send(method: .GET, path: "\(setupAttempts)/\(setupIntent)", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(setupAttempts)/\(setupIntent)", query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Core Resources/SetupAttempt/SetupAttemptRoutes.swift
+++ b/Sources/StripeKit/Core Resources/SetupAttempt/SetupAttemptRoutes.swift
@@ -7,16 +7,17 @@
 
 import NIO
 import NIOHTTP1
+import Baggage
 
 public protocol SetupAttemptRoutes {
-    func listAll(setupIntent: String, filter: [String: Any]?) -> EventLoopFuture<StripeSetupAttemptList>
+    func listAll(setupIntent: String, filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeSetupAttemptList>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
 }
 
 extension SetupAttemptRoutes {
-    public func listAll(setupIntent: String, filter: [String: Any]? = nil) -> EventLoopFuture<StripeSetupAttemptList> {
+    public func listAll(setupIntent: String, filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeSetupAttemptList> {
         listAll(setupIntent: setupIntent, filter: filter)
     }
 }
@@ -31,7 +32,7 @@ public struct StripeSetupAttemptRoutes: SetupAttemptRoutes {
         self.apiHandler = apiHandler
     }
     
-    public func listAll(setupIntent: String, filter: [String: Any]?)-> EventLoopFuture<StripeSetupAttemptList> {
+    public func listAll(setupIntent: String, filter: [String: Any]?, context: LoggingContext)-> EventLoopFuture<StripeSetupAttemptList> {
         var queryParams = ""
         if let filter = filter {
             queryParams = filter.queryParameters

--- a/Sources/StripeKit/Core Resources/SetupIntents/SetupIntentRoutes.swift
+++ b/Sources/StripeKit/Core Resources/SetupIntents/SetupIntentRoutes.swift
@@ -122,11 +122,12 @@ extension SetupIntentsRoutes {
                       returnUrl: returnUrl,
                       singleUse: singleUse,
                       usage: usage,
-                      expand: expand)
+                      expand: expand,
+                      context: context)
     }
     
     public func retrieve(intent: String, clientSecret: String? = nil, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeSetupIntent> {
-        retrieve(intent: intent, clientSecret: clientSecret, expand: expand)
+        retrieve(intent: intent, clientSecret: clientSecret, expand: expand, context: context)
     }
     
     public func update(intent: String,
@@ -143,7 +144,8 @@ extension SetupIntentsRoutes {
                       metadata: metadata,
                       paymentMethod: paymentMethod,
                       paymentMethodTypes: paymentMethodTypes,
-                      expand: expand)
+                      expand: expand,
+                      context: context)
     }
     
     public func confirm(intent: String,
@@ -158,18 +160,19 @@ extension SetupIntentsRoutes {
                        paymentMethod: paymentMethod,
                        paymentMethodOptions: paymentMethodOptions,
                        returnUrl: returnUrl,
-                       expand: expand)
+                       expand: expand,
+                       context: context)
     }
     
     public func cancel(intent: String,
                        cancellationReason: StripeSetupIntentCancellationReason? = nil,
                        expand: [String]? = nil,
                        context: LoggingContext) -> EventLoopFuture<StripeSetupIntent> {
-        return cancel(intent: intent, cancellationReason: cancellationReason, expand: expand)
+        return cancel(intent: intent, cancellationReason: cancellationReason, expand: expand, context: context)
     }
     
     public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeSetupIntentsList> {
-        return listAll(filter: filter)
+        return listAll(filter: filter, context: context)
     }
 }
 
@@ -251,7 +254,7 @@ public struct StripeSetupIntentsRoutes: SetupIntentsRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: setupintents, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: setupintents, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(intent: String, clientSecret: String?, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeSetupIntent> {
@@ -260,7 +263,7 @@ public struct StripeSetupIntentsRoutes: SetupIntentsRoutes {
             queryParams = ["expand": expand].queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: "\(setupintents)/\(intent)", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(setupintents)/\(intent)", query: queryParams, headers: headers, context: context)
     }
     
     public func update(intent: String,
@@ -297,7 +300,7 @@ public struct StripeSetupIntentsRoutes: SetupIntentsRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(setupintents)/\(intent)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(setupintents)/\(intent)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func confirm(intent: String,
@@ -329,7 +332,7 @@ public struct StripeSetupIntentsRoutes: SetupIntentsRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(setupintents)/\(intent)/confirm", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(setupintents)/\(intent)/confirm", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func cancel(intent: String, cancellationReason: StripeSetupIntentCancellationReason?, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeSetupIntent> {
@@ -343,7 +346,7 @@ public struct StripeSetupIntentsRoutes: SetupIntentsRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(setupintents)/\(intent)/cancel", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(setupintents)/\(intent)/cancel", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeSetupIntentsList> {
@@ -352,7 +355,7 @@ public struct StripeSetupIntentsRoutes: SetupIntentsRoutes {
             queryParams = filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: setupintents, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: setupintents, query: queryParams, headers: headers, context: context)
     }
 }
 

--- a/Sources/StripeKit/Core Resources/SetupIntents/SetupIntentRoutes.swift
+++ b/Sources/StripeKit/Core Resources/SetupIntents/SetupIntentRoutes.swift
@@ -7,6 +7,7 @@
 
 import NIO
 import NIOHTTP1
+import Baggage
 
 public protocol SetupIntentsRoutes {
     
@@ -36,13 +37,14 @@ public protocol SetupIntentsRoutes {
                 returnUrl: String?,
                 singleUse: [String: Any]?,
                 usage: String?,
-                expand: [String]?) -> EventLoopFuture<StripeSetupIntent>
+                expand: [String]?,
+                context: LoggingContext) -> EventLoopFuture<StripeSetupIntent>
     
     /// Retrieves the details of a SetupIntent that has previously been created.
     /// - Parameter intent: ID of the SetupIntent to retrieve.
     /// - Parameter clientSecret: The client secret of the SetupIntent. Required if a publishable key is used to retrieve the SetupIntent.
     /// - Parameter expand: An array of properties to expand.
-    func retrieve(intent: String, clientSecret: String?, expand: [String]?) -> EventLoopFuture<StripeSetupIntent>
+    func retrieve(intent: String, clientSecret: String?, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeSetupIntent>
     
     /// Updates a SetupIntent object.
     /// - Parameter intent: ID of the SetupIntent to retrieve.
@@ -58,7 +60,8 @@ public protocol SetupIntentsRoutes {
                 metadata: [String: String]?,
                 paymentMethod: String?,
                 paymentMethodTypes: [String]?,
-                expand: [String]?) -> EventLoopFuture<StripeSetupIntent>
+                expand: [String]?,
+                context: LoggingContext) -> EventLoopFuture<StripeSetupIntent>
     
     /// Confirm that your customer intends to set up the current or provided payment method. For example, you would confirm a SetupIntent when a customer hits the “Save” button on a payment method management page on your website.
     /// If the selected payment method does not require any additional steps from the customer, the SetupIntent will transition to the succeeded status.
@@ -74,18 +77,19 @@ public protocol SetupIntentsRoutes {
                  paymentMethod: String?,
                  paymentMethodOptions: [String: Any]?,
                  returnUrl: String?,
-                 expand: [String]?) -> EventLoopFuture<StripeSetupIntent>
+                 expand: [String]?,
+                 context: LoggingContext) -> EventLoopFuture<StripeSetupIntent>
     
     /// A SetupIntent object can be canceled when it is in one of these statuses: `requires_payment_method`, `requires_capture`, `requires_confirmation`, `requires_action`.
     /// Once canceled, setup is abandoned and any operations on the SetupIntent will fail with an error.
     /// - Parameter intent: ID of the SetupIntent to retrieve.
     /// - Parameter cancellationReason: Reason for canceling this SetupIntent. Possible values are `abandoned`, `requested_by_customer`, or `duplicate`.
     /// - Parameter expand: An array of properties to expand.
-    func cancel(intent: String, cancellationReason: StripeSetupIntentCancellationReason?, expand: [String]?) -> EventLoopFuture<StripeSetupIntent>
+    func cancel(intent: String, cancellationReason: StripeSetupIntentCancellationReason?, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeSetupIntent>
     
     /// Returns a list of SetupIntents.
     /// - Parameter filter: A dictionary that contains the filters. More info [here](https://stripe.com/docs/api/setup_intents/list).
-    func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeSetupIntentsList>
+    func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeSetupIntentsList>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
@@ -104,7 +108,8 @@ extension SetupIntentsRoutes {
                        returnUrl: String? = nil,
                        singleUse: [String: Any]? = nil,
                        usage: String? = nil,
-                       expand: [String]? = nil) -> EventLoopFuture<StripeSetupIntent> {
+                       expand: [String]? = nil,
+                       context: LoggingContext) -> EventLoopFuture<StripeSetupIntent> {
         return create(confirm: confirm,
                       customer: customer,
                       description: description,
@@ -120,7 +125,7 @@ extension SetupIntentsRoutes {
                       expand: expand)
     }
     
-    public func retrieve(intent: String, clientSecret: String? = nil, expand: [String]? = nil) -> EventLoopFuture<StripeSetupIntent> {
+    public func retrieve(intent: String, clientSecret: String? = nil, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeSetupIntent> {
         retrieve(intent: intent, clientSecret: clientSecret, expand: expand)
     }
     
@@ -130,7 +135,8 @@ extension SetupIntentsRoutes {
                        metadata: [String: String]? = nil,
                        paymentMethod: String? = nil,
                        paymentMethodTypes: [String]? = nil,
-                       expand: [String]? = nil) -> EventLoopFuture<StripeSetupIntent> {
+                       expand: [String]? = nil,
+                       context: LoggingContext) -> EventLoopFuture<StripeSetupIntent> {
         return update(intent: intent,
                       customer: customer,
                       description: description,
@@ -145,7 +151,8 @@ extension SetupIntentsRoutes {
                         paymentMethod: String? = nil,
                         paymentMethodOptions: [String: Any]? = nil,
                         returnUrl: String? = nil,
-                        expand: [String]? = nil) -> EventLoopFuture<StripeSetupIntent> {
+                        expand: [String]? = nil,
+                        context: LoggingContext) -> EventLoopFuture<StripeSetupIntent> {
         return confirm(intent: intent,
                        mandateData: mandateData,
                        paymentMethod: paymentMethod,
@@ -156,11 +163,12 @@ extension SetupIntentsRoutes {
     
     public func cancel(intent: String,
                        cancellationReason: StripeSetupIntentCancellationReason? = nil,
-                       expand: [String]? = nil) -> EventLoopFuture<StripeSetupIntent> {
+                       expand: [String]? = nil,
+                       context: LoggingContext) -> EventLoopFuture<StripeSetupIntent> {
         return cancel(intent: intent, cancellationReason: cancellationReason, expand: expand)
     }
     
-    public func listAll(filter: [String: Any]? = nil) -> EventLoopFuture<StripeSetupIntentsList> {
+    public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeSetupIntentsList> {
         return listAll(filter: filter)
     }
 }
@@ -187,7 +195,8 @@ public struct StripeSetupIntentsRoutes: SetupIntentsRoutes {
                        returnUrl: String?,
                        singleUse: [String: Any]?,
                        usage: String?,
-                       expand: [String]?) -> EventLoopFuture<StripeSetupIntent> {
+                       expand: [String]?,
+                       context: LoggingContext) -> EventLoopFuture<StripeSetupIntent> {
         var body: [String: Any] = [:]
         
         if let confirm = confirm {
@@ -245,7 +254,7 @@ public struct StripeSetupIntentsRoutes: SetupIntentsRoutes {
         return apiHandler.send(method: .POST, path: setupintents, body: .string(body.queryParameters), headers: headers)
     }
     
-    public func retrieve(intent: String, clientSecret: String?, expand: [String]?) -> EventLoopFuture<StripeSetupIntent> {
+    public func retrieve(intent: String, clientSecret: String?, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeSetupIntent> {
         var queryParams = ""
         if let expand = expand {
             queryParams = ["expand": expand].queryParameters
@@ -260,7 +269,8 @@ public struct StripeSetupIntentsRoutes: SetupIntentsRoutes {
                        metadata: [String: String]?,
                        paymentMethod: String?,
                        paymentMethodTypes: [String]?,
-                       expand: [String]?) -> EventLoopFuture<StripeSetupIntent> {
+                       expand: [String]?,
+                       context: LoggingContext) -> EventLoopFuture<StripeSetupIntent> {
         var body: [String: Any] = [:]
         
         if let customer = customer {
@@ -295,7 +305,8 @@ public struct StripeSetupIntentsRoutes: SetupIntentsRoutes {
                         paymentMethod: String?,
                         paymentMethodOptions: [String: Any]?,
                         returnUrl: String?,
-                        expand: [String]?) -> EventLoopFuture<StripeSetupIntent> {
+                        expand: [String]?,
+                        context: LoggingContext) -> EventLoopFuture<StripeSetupIntent> {
         var body: [String: Any] = [:]
         
         if let mandateData = mandateData {
@@ -321,7 +332,7 @@ public struct StripeSetupIntentsRoutes: SetupIntentsRoutes {
         return apiHandler.send(method: .POST, path: "\(setupintents)/\(intent)/confirm", body: .string(body.queryParameters), headers: headers)
     }
     
-    public func cancel(intent: String, cancellationReason: StripeSetupIntentCancellationReason?, expand: [String]?) -> EventLoopFuture<StripeSetupIntent> {
+    public func cancel(intent: String, cancellationReason: StripeSetupIntentCancellationReason?, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeSetupIntent> {
         var body: [String: Any] = [:]
         
         if let cancellationReason = cancellationReason {
@@ -335,7 +346,7 @@ public struct StripeSetupIntentsRoutes: SetupIntentsRoutes {
         return apiHandler.send(method: .POST, path: "\(setupintents)/\(intent)/cancel", body: .string(body.queryParameters), headers: headers)
     }
     
-    public func listAll(filter: [String: Any]? = nil) -> EventLoopFuture<StripeSetupIntentsList> {
+    public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeSetupIntentsList> {
         var queryParams = ""
         if let filter = filter {
             queryParams = filter.queryParameters

--- a/Sources/StripeKit/Core Resources/Tokens/TokenRoutes.swift
+++ b/Sources/StripeKit/Core Resources/Tokens/TokenRoutes.swift
@@ -8,6 +8,7 @@
 
 import NIO
 import NIOHTTP1
+import Baggage
 
 public protocol TokenRoutes {
     /// Creates a single-use token that represents a credit card’s details. This token can be used in place of a credit card dictionary with any API method. These tokens can be used only once: by creating a new Charge object, or by attaching them to a Customer object. /n In most cases, you should use our recommended payments integrations instead of using the API.
@@ -16,7 +17,7 @@ public protocol TokenRoutes {
     ///   - card: The card this token will represent. If you also pass in a customer, the card must be the ID of a card belonging to the customer. Otherwise, if you do not pass in a customer, this is a dictionary containing a user's credit card details, with the options described below.
     ///   - customer: The customer (owned by the application's account) for which to create a token. For use only with Stripe Connect. Also, this can be used only with an OAuth access token or Stripe-Account header. For more details, see Shared Customers.
     /// - Returns: A `StripeToken`.
-    func create(card: Any?, customer: String?) -> EventLoopFuture<StripeToken>
+    func create(card: Any?, customer: String?, context: LoggingContext) -> EventLoopFuture<StripeToken>
     
     /// Creates a single-use token that represents a bank account’s details. This token can be used with any API method in place of a bank account dictionary. This token can be used only once, by attaching it to a Custom account.
     ///
@@ -24,56 +25,56 @@ public protocol TokenRoutes {
     ///   - bankAcocunt: The bank account this token will represent.
     ///   - customer: The customer (owned by the application’s account) for which to create a token. For use only with Stripe Connect. Also, this can be used only with an OAuth access token or Stripe-Account header. For more details, see Shared Customers.
     /// - Returns: A `StripeToken`.
-    func create(bankAcocunt: [String: Any]?, customer: String?) -> EventLoopFuture<StripeToken>
+    func create(bankAcocunt: [String: Any]?, customer: String?, context: LoggingContext) -> EventLoopFuture<StripeToken>
     
     /// Creates a single-use token that represents the details of personally identifiable information (PII). This token can be used in place of an id_number in Account or Person Update API methods. A PII token can be used only once.
     ///
     /// - Parameter pii: The PII this token will represent.
     /// - Returns: A `StripeToken`.
-    func create(pii: String) -> EventLoopFuture<StripeToken>
+    func create(pii: String, context: LoggingContext) -> EventLoopFuture<StripeToken>
     
     /// Creates a single-use token that wraps a user’s legal entity information. Use this when creating or updating a Connect account. See the account tokens documentation to learn more. /n Account tokens may be created only in live mode, with your application’s publishable key. Your application’s secret key may be used to create account tokens only in test mode.
     ///
     /// - Parameter account: Information for the account this token will represent.
     /// - Returns: A `StripeToken`.
-    func create(account: [String: Any]) -> EventLoopFuture<StripeToken>
+    func create(account: [String: Any], context: LoggingContext) -> EventLoopFuture<StripeToken>
     
     /// Creates a single-use token that represents the details for a person. Use this when creating or updating persons associated with a Connect account. See the documentation to learn more. Person tokens may be created only in live mode, with your application’s publishable key. Your application’s secret key may be used to create person tokens only in test mode.
     /// - Parameter person: Information for the person this token will represent.
-    func create(person: [String: Any]) -> EventLoopFuture<StripePerson>
+    func create(person: [String: Any], context: LoggingContext) -> EventLoopFuture<StripePerson>
     
     /// Retrieves the token with the given ID.
     ///
     /// - Parameter token: The ID of the desired token.
     /// - Returns: A `StripeToken`.
-    func retrieve(token: String) -> EventLoopFuture<StripeToken>
+    func retrieve(token: String, context: LoggingContext) -> EventLoopFuture<StripeToken>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
 }
 
 extension TokenRoutes {
-    public func create(card: Any? = nil, customer: String? = nil) -> EventLoopFuture<StripeToken> {
+    public func create(card: Any? = nil, customer: String? = nil, context: LoggingContext) -> EventLoopFuture<StripeToken> {
         return create(card: card, customer: customer)
     }
     
-    public func create(bankAcocunt: [String: Any]? = nil, customer: String? = nil) -> EventLoopFuture<StripeToken> {
+    public func create(bankAcocunt: [String: Any]? = nil, customer: String? = nil, context: LoggingContext) -> EventLoopFuture<StripeToken> {
         return create(bankAcocunt: bankAcocunt, customer: customer)
     }
     
-    public func create(pii: String) -> EventLoopFuture<StripeToken> {
+    public func create(pii: String, context: LoggingContext) -> EventLoopFuture<StripeToken> {
         return create(pii: pii)
     }
     
-    public func create(account: [String: Any]) -> EventLoopFuture<StripeToken> {
+    public func create(account: [String: Any], context: LoggingContext) -> EventLoopFuture<StripeToken> {
         return create(account: account)
     }
     
-    public func create(person: [String: Any]) -> EventLoopFuture<StripePerson> {
+    public func create(person: [String: Any], context: LoggingContext) -> EventLoopFuture<StripePerson> {
         return create(person: person)
     }
     
-    public func retrieve(token: String) -> EventLoopFuture<StripeToken> {
+    public func retrieve(token: String, context: LoggingContext) -> EventLoopFuture<StripeToken> {
         return retrieve(token: token)
     }
 }
@@ -88,7 +89,7 @@ public struct StripeTokenRoutes: TokenRoutes {
         self.apiHandler = apiHandler
     }
 
-    public func create(card: Any?, customer: String?) -> EventLoopFuture<StripeToken> {
+    public func create(card: Any?, customer: String?, context: LoggingContext) -> EventLoopFuture<StripeToken> {
         var body: [String: Any] = [:]
         
         if let card = card as? [String: Any] {
@@ -106,7 +107,7 @@ public struct StripeTokenRoutes: TokenRoutes {
         return apiHandler.send(method: .POST, path: tokens, body: .string(body.queryParameters), headers: headers)
     }
     
-    public func create(bankAcocunt: [String: Any]?, customer: String?) -> EventLoopFuture<StripeToken> {
+    public func create(bankAcocunt: [String: Any]?, customer: String?, context: LoggingContext) -> EventLoopFuture<StripeToken> {
         var body: [String: Any] = [:]
         
         if let bankAcocunt = bankAcocunt {
@@ -120,13 +121,13 @@ public struct StripeTokenRoutes: TokenRoutes {
         return apiHandler.send(method: .POST, path: tokens, body: .string(body.queryParameters), headers: headers)
     }
     
-    public func create(pii: String) -> EventLoopFuture<StripeToken> {
+    public func create(pii: String, context: LoggingContext) -> EventLoopFuture<StripeToken> {
         let body: [String: Any] = ["personal_id_number": pii]
         
         return apiHandler.send(method: .POST, path: tokens, body: .string(body.queryParameters), headers: headers)
     }
     
-    public func create(account: [String: Any]) -> EventLoopFuture<StripeToken> {
+    public func create(account: [String: Any], context: LoggingContext) -> EventLoopFuture<StripeToken> {
         var body: [String: Any] = [:]
         
         account.forEach { body["account[\($0)]"] = $1 }
@@ -134,7 +135,7 @@ public struct StripeTokenRoutes: TokenRoutes {
         return apiHandler.send(method: .POST, path: tokens, body: .string(body.queryParameters), headers: headers)
     }
     
-    public func create(person: [String : Any]) -> EventLoopFuture<StripePerson> {
+    public func create(person: [String : Any], context: LoggingContext) -> EventLoopFuture<StripePerson> {
         var body: [String: Any] = [:]
         
         person.forEach { body["person[\($0)]"] = $1 }
@@ -142,7 +143,7 @@ public struct StripeTokenRoutes: TokenRoutes {
         return apiHandler.send(method: .POST, path: tokens, body: .string(body.queryParameters), headers: headers)
     }
     
-    public func retrieve(token: String) -> EventLoopFuture<StripeToken> {
+    public func retrieve(token: String, context: LoggingContext) -> EventLoopFuture<StripeToken> {
         return apiHandler.send(method: .GET, path: "\(tokens)/\(token)", headers: headers)
     }
 }

--- a/Sources/StripeKit/Core Resources/Tokens/TokenRoutes.swift
+++ b/Sources/StripeKit/Core Resources/Tokens/TokenRoutes.swift
@@ -55,27 +55,27 @@ public protocol TokenRoutes {
 
 extension TokenRoutes {
     public func create(card: Any? = nil, customer: String? = nil, context: LoggingContext) -> EventLoopFuture<StripeToken> {
-        return create(card: card, customer: customer)
+        return create(card: card, customer: customer, context: context)
     }
     
     public func create(bankAcocunt: [String: Any]? = nil, customer: String? = nil, context: LoggingContext) -> EventLoopFuture<StripeToken> {
-        return create(bankAcocunt: bankAcocunt, customer: customer)
+        return create(bankAcocunt: bankAcocunt, customer: customer, context: context)
     }
     
     public func create(pii: String, context: LoggingContext) -> EventLoopFuture<StripeToken> {
-        return create(pii: pii)
+        return create(pii: pii, context: context)
     }
     
     public func create(account: [String: Any], context: LoggingContext) -> EventLoopFuture<StripeToken> {
-        return create(account: account)
+        return create(account: account, context: context)
     }
     
     public func create(person: [String: Any], context: LoggingContext) -> EventLoopFuture<StripePerson> {
-        return create(person: person)
+        return create(person: person, context: context)
     }
     
     public func retrieve(token: String, context: LoggingContext) -> EventLoopFuture<StripeToken> {
-        return retrieve(token: token)
+        return retrieve(token: token, context: context)
     }
 }
 
@@ -104,7 +104,7 @@ public struct StripeTokenRoutes: TokenRoutes {
             body["customer"] = customer
         }
         
-        return apiHandler.send(method: .POST, path: tokens, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: tokens, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func create(bankAcocunt: [String: Any]?, customer: String?, context: LoggingContext) -> EventLoopFuture<StripeToken> {
@@ -118,13 +118,13 @@ public struct StripeTokenRoutes: TokenRoutes {
             body["customer"] = customer
         }
         
-        return apiHandler.send(method: .POST, path: tokens, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: tokens, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func create(pii: String, context: LoggingContext) -> EventLoopFuture<StripeToken> {
         let body: [String: Any] = ["personal_id_number": pii]
         
-        return apiHandler.send(method: .POST, path: tokens, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: tokens, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func create(account: [String: Any], context: LoggingContext) -> EventLoopFuture<StripeToken> {
@@ -132,7 +132,7 @@ public struct StripeTokenRoutes: TokenRoutes {
         
         account.forEach { body["account[\($0)]"] = $1 }
         
-        return apiHandler.send(method: .POST, path: tokens, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: tokens, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func create(person: [String : Any], context: LoggingContext) -> EventLoopFuture<StripePerson> {
@@ -140,10 +140,10 @@ public struct StripeTokenRoutes: TokenRoutes {
         
         person.forEach { body["person[\($0)]"] = $1 }
         
-        return apiHandler.send(method: .POST, path: tokens, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: tokens, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(token: String, context: LoggingContext) -> EventLoopFuture<StripeToken> {
-        return apiHandler.send(method: .GET, path: "\(tokens)/\(token)", headers: headers)
+        return apiHandler.send(method: .GET, path: "\(tokens)/\(token)", headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/EphemeralKey/EphemeralKeyRoutes.swift
+++ b/Sources/StripeKit/EphemeralKey/EphemeralKeyRoutes.swift
@@ -19,11 +19,11 @@ public protocol EphemeralKeyRoutes {
 
 extension EphemeralKeyRoutes {
     public func create(customer: String, issuingCard: String? = nil, context: LoggingContext) -> EventLoopFuture<StripeEphemeralKey> {
-        return create(customer: customer, issuingCard: issuingCard)
+        return create(customer: customer, issuingCard: issuingCard, context: context)
     }
     
     public func delete(ephemeralKey: String, context: LoggingContext) -> EventLoopFuture<StripeEphemeralKey> {
-        return delete(ephemeralKey: ephemeralKey)
+        return delete(ephemeralKey: ephemeralKey, context: context)
     }
 }
 
@@ -44,10 +44,10 @@ public struct StripeEphemeralKeyRoutes: EphemeralKeyRoutes {
             body["issuing_card"] = issuingCard
         }
         
-        return apiHandler.send(method: .POST, path: ephemeralkeys, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: ephemeralkeys, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func delete(ephemeralKey: String, context: LoggingContext) -> EventLoopFuture<StripeEphemeralKey> {
-        return apiHandler.send(method: .DELETE, path: "\(ephemeralkeys)/\(ephemeralKey)", headers: headers)
+        return apiHandler.send(method: .DELETE, path: "\(ephemeralkeys)/\(ephemeralKey)", headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/EphemeralKey/EphemeralKeyRoutes.swift
+++ b/Sources/StripeKit/EphemeralKey/EphemeralKeyRoutes.swift
@@ -7,21 +7,22 @@
 
 import NIO
 import NIOHTTP1
+import Baggage
 
 public protocol EphemeralKeyRoutes {
-    func create(customer: String, issuingCard: String?) -> EventLoopFuture<StripeEphemeralKey>
-    func delete(ephemeralKey: String) -> EventLoopFuture<StripeEphemeralKey>
+    func create(customer: String, issuingCard: String?, context: LoggingContext) -> EventLoopFuture<StripeEphemeralKey>
+    func delete(ephemeralKey: String, context: LoggingContext) -> EventLoopFuture<StripeEphemeralKey>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
 }
 
 extension EphemeralKeyRoutes {
-    public func create(customer: String, issuingCard: String? = nil) -> EventLoopFuture<StripeEphemeralKey> {
+    public func create(customer: String, issuingCard: String? = nil, context: LoggingContext) -> EventLoopFuture<StripeEphemeralKey> {
         return create(customer: customer, issuingCard: issuingCard)
     }
     
-    public func delete(ephemeralKey: String) -> EventLoopFuture<StripeEphemeralKey> {
+    public func delete(ephemeralKey: String, context: LoggingContext) -> EventLoopFuture<StripeEphemeralKey> {
         return delete(ephemeralKey: ephemeralKey)
     }
 }
@@ -36,7 +37,7 @@ public struct StripeEphemeralKeyRoutes: EphemeralKeyRoutes {
         self.apiHandler = apiHandler
     }
     
-    public func create(customer: String, issuingCard: String?) -> EventLoopFuture<StripeEphemeralKey> {
+    public func create(customer: String, issuingCard: String?, context: LoggingContext) -> EventLoopFuture<StripeEphemeralKey> {
         var body: [String: Any] = ["customer": customer]
         
         if let issuingCard = issuingCard {
@@ -46,7 +47,7 @@ public struct StripeEphemeralKeyRoutes: EphemeralKeyRoutes {
         return apiHandler.send(method: .POST, path: ephemeralkeys, body: .string(body.queryParameters), headers: headers)
     }
     
-    public func delete(ephemeralKey: String) -> EventLoopFuture<StripeEphemeralKey> {
+    public func delete(ephemeralKey: String, context: LoggingContext) -> EventLoopFuture<StripeEphemeralKey> {
         return apiHandler.send(method: .DELETE, path: "\(ephemeralkeys)/\(ephemeralKey)", headers: headers)
     }
 }

--- a/Sources/StripeKit/Fraud/Early Fraud Warnings/EarlyFraudWarningRoutes.swift
+++ b/Sources/StripeKit/Fraud/Early Fraud Warnings/EarlyFraudWarningRoutes.swift
@@ -7,28 +7,29 @@
 
 import NIO
 import NIOHTTP1
+import Baggage
 
 public protocol EarlyFraudWarningRoutes {
     
     /// Retrieves the details of an early fraud warning that has previously been created.
     /// - Parameter earlyFraudWarning: The identifier of the early fraud warning to be retrieved.
     /// - Parameter expand: An array of properties to expand.
-    func retrieve(earlyFraudWarning: String, expand: [String]?) -> EventLoopFuture<StripeEarlyFraudWarning>
+    func retrieve(earlyFraudWarning: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeEarlyFraudWarning>
     
     /// Returns a list of early fraud warnings.
     /// - Parameter filter: A dictionary that will be used for the query parameters. [See More →](https://stripe.com/docs/api/radar/early_fraud_warnings/list).
-    func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeEarlyFraudWarningList>
+    func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeEarlyFraudWarningList>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
 }
 
 extension EarlyFraudWarningRoutes {
-    public func retrieve(earlyFraudWarning: String, expand: [String]? = nil) -> EventLoopFuture<StripeEarlyFraudWarning> {
+    public func retrieve(earlyFraudWarning: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeEarlyFraudWarning> {
         return retrieve(earlyFraudWarning: earlyFraudWarning, expand: expand)
     }
     
-    public func listAll(filter: [String: Any]? = nil) -> EventLoopFuture<StripeEarlyFraudWarningList> {
+    public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeEarlyFraudWarningList> {
         return listAll(filter: filter)
     }
 }
@@ -43,7 +44,7 @@ public struct StripeEarlyFraudWarningRoutes: EarlyFraudWarningRoutes {
         self.apiHandler = apiHandler
     }
     
-    public func retrieve(earlyFraudWarning: String, expand: [String]?) -> EventLoopFuture<StripeEarlyFraudWarning> {
+    public func retrieve(earlyFraudWarning: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeEarlyFraudWarning> {
         var queryParams = ""
         if let expand = expand {
             queryParams = ["expand": expand].queryParameters
@@ -52,7 +53,7 @@ public struct StripeEarlyFraudWarningRoutes: EarlyFraudWarningRoutes {
         return apiHandler.send(method: .GET, path: "\(earlyfraudwarnings)/\(earlyFraudWarning)", query: queryParams, headers: headers)
     }
     
-    public func listAll(filter: [String : Any]? = nil) -> EventLoopFuture<StripeEarlyFraudWarningList> {
+    public func listAll(filter: [String : Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeEarlyFraudWarningList> {
         var queryParams = ""
         if let filter = filter {
             queryParams = filter.queryParameters

--- a/Sources/StripeKit/Fraud/Early Fraud Warnings/EarlyFraudWarningRoutes.swift
+++ b/Sources/StripeKit/Fraud/Early Fraud Warnings/EarlyFraudWarningRoutes.swift
@@ -26,11 +26,11 @@ public protocol EarlyFraudWarningRoutes {
 
 extension EarlyFraudWarningRoutes {
     public func retrieve(earlyFraudWarning: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeEarlyFraudWarning> {
-        return retrieve(earlyFraudWarning: earlyFraudWarning, expand: expand)
+        return retrieve(earlyFraudWarning: earlyFraudWarning, expand: expand, context: context)
     }
     
     public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeEarlyFraudWarningList> {
-        return listAll(filter: filter)
+        return listAll(filter: filter, context: context)
     }
 }
 
@@ -50,7 +50,7 @@ public struct StripeEarlyFraudWarningRoutes: EarlyFraudWarningRoutes {
             queryParams = ["expand": expand].queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: "\(earlyfraudwarnings)/\(earlyFraudWarning)", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(earlyfraudwarnings)/\(earlyFraudWarning)", query: queryParams, headers: headers, context: context)
     }
     
     public func listAll(filter: [String : Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeEarlyFraudWarningList> {
@@ -59,6 +59,6 @@ public struct StripeEarlyFraudWarningRoutes: EarlyFraudWarningRoutes {
             queryParams = filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: earlyfraudwarnings, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: earlyfraudwarnings, query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Fraud/Reviews/ReviewRoutes.swift
+++ b/Sources/StripeKit/Fraud/Reviews/ReviewRoutes.swift
@@ -36,15 +36,15 @@ public protocol ReviewRoutes {
 
 extension ReviewRoutes {
     func approve(review: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeReview> {
-        return approve(review: review, expand: expand)
+        return approve(review: review, expand: expand, context: context)
     }
     
     func retrieve(review: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeReview> {
-        return retrieve(review: review, expand: expand)
+        return retrieve(review: review, expand: expand, context: context)
     }
     
     func listAll(filter: [String: Any]? = nil, context: LoggingContext)  -> EventLoopFuture<StripeReviewList> {
-        return listAll(filter: filter)
+        return listAll(filter: filter, context: context)
     }
 }
 
@@ -65,7 +65,7 @@ public struct StripeReviewRoutes: ReviewRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(reviews)\(review)/approve", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(reviews)\(review)/approve", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(review: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeReview> {
@@ -74,7 +74,7 @@ public struct StripeReviewRoutes: ReviewRoutes {
             queryParams = ["expand": expand].queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: "\(reviews)\(review)", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(reviews)\(review)", query: queryParams, headers: headers, context: context)
     }
     
     public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeReviewList> {
@@ -82,6 +82,6 @@ public struct StripeReviewRoutes: ReviewRoutes {
         if let filter = filter {
             queryParams = filter.queryParameters
         }
-        return apiHandler.send(method: .GET, path: reviews, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: reviews, query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Fraud/Reviews/ReviewRoutes.swift
+++ b/Sources/StripeKit/Fraud/Reviews/ReviewRoutes.swift
@@ -7,6 +7,7 @@
 
 import NIO
 import NIOHTTP1
+import Baggage
 
 public protocol ReviewRoutes {
     /// Approves a `Review` object, closing it and removing it from the list of reviews.
@@ -14,35 +15,35 @@ public protocol ReviewRoutes {
     /// - Parameter review: The identifier of the review to be approved.
     /// - Parameter expand: An array of properties to expand.
     /// - Returns: A `StripeReview`.
-    func approve(review: String, expand: [String]?) -> EventLoopFuture<StripeReview>
+    func approve(review: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeReview>
     
     /// Retrieves a Review object.
     ///
     /// - Parameter review: The identifier of the review to be retrieved.
     /// - Parameter expand: An array of properties to expand.
     /// - Returns: A `StripeReview`.
-    func retrieve(review: String, expand: [String]?) -> EventLoopFuture<StripeReview>
+    func retrieve(review: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeReview>
     
     /// Returns a list of `Review` objects that have `open` set to `true`. The objects are sorted in descending order by creation date, with the most recently created object appearing first.
     ///
     /// - Parameter filter: A dictionary that will be used for the query parameters. [See More →](https://stripe.com/docs/api/radar/reviews/list).
     /// - Returns: A `StripeReviewList`.
-    func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeReviewList>
+    func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeReviewList>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
 }
 
 extension ReviewRoutes {
-    func approve(review: String, expand: [String]? = nil) -> EventLoopFuture<StripeReview> {
+    func approve(review: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeReview> {
         return approve(review: review, expand: expand)
     }
     
-    func retrieve(review: String, expand: [String]? = nil) -> EventLoopFuture<StripeReview> {
+    func retrieve(review: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeReview> {
         return retrieve(review: review, expand: expand)
     }
     
-    func listAll(filter: [String: Any]? = nil)  -> EventLoopFuture<StripeReviewList> {
+    func listAll(filter: [String: Any]? = nil, context: LoggingContext)  -> EventLoopFuture<StripeReviewList> {
         return listAll(filter: filter)
     }
 }
@@ -57,7 +58,7 @@ public struct StripeReviewRoutes: ReviewRoutes {
         self.apiHandler = apiHandler
     }    
     
-    public func approve(review: String, expand: [String]?) -> EventLoopFuture<StripeReview> {
+    public func approve(review: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeReview> {
         var body: [String: Any] = [:]
         
         if let expand = expand {
@@ -67,7 +68,7 @@ public struct StripeReviewRoutes: ReviewRoutes {
         return apiHandler.send(method: .POST, path: "\(reviews)\(review)/approve", body: .string(body.queryParameters), headers: headers)
     }
     
-    public func retrieve(review: String, expand: [String]?) -> EventLoopFuture<StripeReview> {
+    public func retrieve(review: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeReview> {
         var queryParams = ""
         if let expand = expand {
             queryParams = ["expand": expand].queryParameters
@@ -76,7 +77,7 @@ public struct StripeReviewRoutes: ReviewRoutes {
         return apiHandler.send(method: .GET, path: "\(reviews)\(review)", query: queryParams, headers: headers)
     }
     
-    public func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeReviewList> {
+    public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeReviewList> {
         var queryParams = ""
         if let filter = filter {
             queryParams = filter.queryParameters

--- a/Sources/StripeKit/Fraud/Value List items/ValueListItemRoutes.swift
+++ b/Sources/StripeKit/Fraud/Value List items/ValueListItemRoutes.swift
@@ -7,6 +7,7 @@
 
 import NIO
 import NIOHTTP1
+import Baggage
 
 public protocol ValueListItemRoutes {
     /// Creates a new `ValueListItem` object, which is added to the specified parent value list.
@@ -15,44 +16,44 @@ public protocol ValueListItemRoutes {
     ///   - value: The value of the item (whose type must match the type of the parent value list).
     ///   - valueList: The identifier of the value list which the created item will be added to.
     /// - Returns: A `StripeValueListItem`.
-    func create(value: String, valueList: String) -> EventLoopFuture<StripeValueListItem>
+    func create(value: String, valueList: String, context: LoggingContext) -> EventLoopFuture<StripeValueListItem>
     
     /// Retrieves a `ValueListItem` object.
     ///
     /// - Parameter item: The identifier of the value list item to be retrieved.
     /// - Returns: A `StripeValueListItem`.
-    func retrieve(item: String) -> EventLoopFuture<StripeValueListItem>
+    func retrieve(item: String, context: LoggingContext) -> EventLoopFuture<StripeValueListItem>
     
     /// Deletes a `ValueListItem` object, removing it from its parent value list.
     ///
     /// - Parameter item: The identifier of the value list item to be deleted.
     /// - Returns: A `StripeValueListItem`.
-    func delete(item: String) -> EventLoopFuture<StripeDeletedObject>
+    func delete(item: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject>
     
     /// Returns a list of `ValueListItem` objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.
     ///
     /// - Parameter filter: A dictionary that will be used for the query parameters. [See More →](https://stripe.com/docs/api/radar/value_list_items/list).
     /// - Returns: A `StripeValueListItemList`.
-    func listAll(valueList: String, filter: [String: Any]?) -> EventLoopFuture<StripeValueListItemList>
+    func listAll(valueList: String, filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeValueListItemList>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
 }
 
 extension ValueListItemRoutes {
-    func create(value: String, valueList: String) -> EventLoopFuture<StripeValueListItem> {
+    func create(value: String, valueList: String, context: LoggingContext) -> EventLoopFuture<StripeValueListItem> {
         return create(value: value, valueList: valueList)
     }
     
-    func retrieve(item: String) -> EventLoopFuture<StripeValueListItem> {
+    func retrieve(item: String, context: LoggingContext) -> EventLoopFuture<StripeValueListItem> {
         return retrieve(item: item)
     }
     
-    func delete(item: String) -> EventLoopFuture<StripeDeletedObject> {
+    func delete(item: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
         return delete(item: item)
     }
     
-    func listAll(valueList: String, filter: [String: Any]? = nil) -> EventLoopFuture<StripeValueListItemList> {
+    func listAll(valueList: String, filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeValueListItemList> {
         return listAll(valueList: valueList, filter: filter)
     }
 }
@@ -67,20 +68,20 @@ public struct StripeValueListItemRoutes: ValueListItemRoutes {
         self.apiHandler = apiHandler
     }
     
-    public func create(value: String, valueList: String) -> EventLoopFuture<StripeValueListItem> {
+    public func create(value: String, valueList: String, context: LoggingContext) -> EventLoopFuture<StripeValueListItem> {
         let body = ["value": value, "value_list": valueList]
         return apiHandler.send(method: .POST, path: valuelistitems, body: .string(body.queryParameters), headers: headers)
     }
     
-    public func retrieve(item: String) -> EventLoopFuture<StripeValueListItem> {
+    public func retrieve(item: String, context: LoggingContext) -> EventLoopFuture<StripeValueListItem> {
         return apiHandler.send(method: .GET, path: "\(valuelistitems)/\(item)", headers: headers)
     }
     
-    public func delete(item: String) -> EventLoopFuture<StripeDeletedObject> {
+    public func delete(item: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
         return apiHandler.send(method: .DELETE, path: "\(valuelistitems)/\(item)", headers: headers)
     }
     
-    public func listAll(valueList: String, filter: [String: Any]?) -> EventLoopFuture<StripeValueListItemList> {
+    public func listAll(valueList: String, filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeValueListItemList> {
         var queryParams = "value_list=\(valueList)"
         if let filter = filter {
             queryParams += "&" + filter.queryParameters

--- a/Sources/StripeKit/Fraud/Value List items/ValueListItemRoutes.swift
+++ b/Sources/StripeKit/Fraud/Value List items/ValueListItemRoutes.swift
@@ -42,19 +42,19 @@ public protocol ValueListItemRoutes {
 
 extension ValueListItemRoutes {
     func create(value: String, valueList: String, context: LoggingContext) -> EventLoopFuture<StripeValueListItem> {
-        return create(value: value, valueList: valueList)
+        return create(value: value, valueList: valueList, context: context)
     }
     
     func retrieve(item: String, context: LoggingContext) -> EventLoopFuture<StripeValueListItem> {
-        return retrieve(item: item)
+        return retrieve(item: item, context: context)
     }
     
     func delete(item: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
-        return delete(item: item)
+        return delete(item: item, context: context)
     }
     
     func listAll(valueList: String, filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeValueListItemList> {
-        return listAll(valueList: valueList, filter: filter)
+        return listAll(valueList: valueList, filter: filter, context: context)
     }
 }
 
@@ -70,15 +70,15 @@ public struct StripeValueListItemRoutes: ValueListItemRoutes {
     
     public func create(value: String, valueList: String, context: LoggingContext) -> EventLoopFuture<StripeValueListItem> {
         let body = ["value": value, "value_list": valueList]
-        return apiHandler.send(method: .POST, path: valuelistitems, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: valuelistitems, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(item: String, context: LoggingContext) -> EventLoopFuture<StripeValueListItem> {
-        return apiHandler.send(method: .GET, path: "\(valuelistitems)/\(item)", headers: headers)
+        return apiHandler.send(method: .GET, path: "\(valuelistitems)/\(item)", headers: headers, context: context)
     }
     
     public func delete(item: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
-        return apiHandler.send(method: .DELETE, path: "\(valuelistitems)/\(item)", headers: headers)
+        return apiHandler.send(method: .DELETE, path: "\(valuelistitems)/\(item)", headers: headers, context: context)
     }
     
     public func listAll(valueList: String, filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeValueListItemList> {
@@ -86,6 +86,6 @@ public struct StripeValueListItemRoutes: ValueListItemRoutes {
         if let filter = filter {
             queryParams += "&" + filter.queryParameters
         }
-        return apiHandler.send(method: .GET, path: valuelistitems, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: valuelistitems, query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Fraud/Value Lists/ValueListRoutes.swift
+++ b/Sources/StripeKit/Fraud/Value Lists/ValueListRoutes.swift
@@ -59,13 +59,14 @@ extension ValueListRoutes {
                 metadata: [String: String]? = nil,
                 context: LoggingContext) -> EventLoopFuture<StripeValueList> {
         return create(alias: alias,
-                          name: name,
-                          itemType: itemType,
-                          metadata: metadata)
+                      name: name,
+                      itemType: itemType,
+                      metadata: metadata,
+                      context: context)
     }
     
     func retrieve(valueList: String, context: LoggingContext) -> EventLoopFuture<StripeValueList> {
-        return retrieve(valueList: valueList)
+        return retrieve(valueList: valueList, context: context)
     }
     
     func update(valueList: String,
@@ -74,17 +75,18 @@ extension ValueListRoutes {
                 name: String? = nil,
                 context: LoggingContext) -> EventLoopFuture<StripeValueList> {
         return update(valueList: valueList,
-                          alias: alias,
-                          metadata: metadata,
-                          name: name)
+                      alias: alias,
+                      metadata: metadata,
+                      name: name,
+                      context: context)
     }
     
     func delete(valueList: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
-        return delete(valueList: valueList)
+        return delete(valueList: valueList, context: context)
     }
     
     func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeValueListList> {
-        return listAll(filter: filter)
+        return listAll(filter: filter, context: context)
     }
 }
 
@@ -114,11 +116,11 @@ public struct StripeValueListRoutes: ValueListRoutes {
             metadata.forEach { body["metadata[\($0)]"] = $1 }
         }
         
-        return apiHandler.send(method: .POST, path: valuelists, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: valuelists, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(valueList: String, context: LoggingContext) -> EventLoopFuture<StripeValueList> {
-        return apiHandler.send(method: .GET, path: "\(valuelists)/\(valueList)", headers: headers)
+        return apiHandler.send(method: .GET, path: "\(valuelists)/\(valueList)", headers: headers, context: context)
     }
     
     public func update(valueList: String,
@@ -140,11 +142,11 @@ public struct StripeValueListRoutes: ValueListRoutes {
             body["name"] = name
         }
         
-        return apiHandler.send(method: .POST, path: "\(valuelists)/\(valueList)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(valuelists)/\(valueList)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func delete(valueList: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
-        return apiHandler.send(method: .DELETE, path: "\(valuelists)/\(valueList)", headers: headers)
+        return apiHandler.send(method: .DELETE, path: "\(valuelists)/\(valueList)", headers: headers, context: context)
     }
     
     public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeValueListList> {
@@ -152,6 +154,6 @@ public struct StripeValueListRoutes: ValueListRoutes {
         if let filter = filter {
             queryParams = filter.queryParameters
         }
-        return apiHandler.send(method: .GET, path: valuelists, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: valuelists, query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Fraud/Value Lists/ValueListRoutes.swift
+++ b/Sources/StripeKit/Fraud/Value Lists/ValueListRoutes.swift
@@ -7,6 +7,7 @@
 
 import NIO
 import NIOHTTP1
+import Baggage
 
 public protocol ValueListRoutes {
     /// Creates a new `ValueList` object, which can then be referenced in rules.
@@ -17,13 +18,13 @@ public protocol ValueListRoutes {
     ///   - itemType: Type of the items in the value list. One of `card_fingerprint`, `card_bin`, `email`, `ip_address`, `country`, `string`, or`case_sensitive_string`. Use string if the item type is unknown or mixed.
     ///   - metadata: Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
     /// - Returns: A`StripeValueList`.
-    func create(alias: String, name: String, itemType: StripeValueListItemType?, metadata: [String: String]?) -> EventLoopFuture<StripeValueList>
+    func create(alias: String, name: String, itemType: StripeValueListItemType?, metadata: [String: String]?, context: LoggingContext) -> EventLoopFuture<StripeValueList>
     
     /// Retrieves a `ValueList` object.
     ///
     /// - Parameter valueList: The identifier of the value list to be retrieved.
     /// - Returns: A`StripeValueList`.
-    func retrieve(valueList: String) -> EventLoopFuture<StripeValueList>
+    func retrieve(valueList: String, context: LoggingContext) -> EventLoopFuture<StripeValueList>
     
     /// Updates a `ValueList` object by setting the values of the parameters passed. Any parameters not provided will be left unchanged. Note that `item_type` is immutable.
     ///
@@ -33,19 +34,19 @@ public protocol ValueListRoutes {
     ///   - metadata: Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
     ///   - name: The human-readable name of the value list.
     /// - Returns: A`StripeValueList`.
-    func update(valueList: String, alias: String?, metadata: [String: String]?, name: String?) -> EventLoopFuture<StripeValueList>
+    func update(valueList: String, alias: String?, metadata: [String: String]?, name: String?, context: LoggingContext) -> EventLoopFuture<StripeValueList>
     
     /// Deletes a `ValueList` object, also deleting any items contained within the value list. To be deleted, a value list must not be referenced in any rules.
     ///
     /// - Parameter valueList: The identifier of the value list to be deleted.
     /// - Returns: A `StripeDeletedObject`.
-    func delete(valueList: String) -> EventLoopFuture<StripeDeletedObject>
+    func delete(valueList: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject>
     
     /// Returns a list of `ValueList` objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.
     ///
     /// - Parameter filter: A dictionary that will be used for the query parameters. [See More →](https://stripe.com/docs/api/radar/value_lists/list).
     /// - Returns: A `StripeValueListList`
-    func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeValueListList>
+    func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeValueListList>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
@@ -55,32 +56,34 @@ extension ValueListRoutes {
     func create(alias: String,
                 name: String,
                 itemType: StripeValueListItemType? = nil,
-                metadata: [String: String]? = nil) -> EventLoopFuture<StripeValueList> {
+                metadata: [String: String]? = nil,
+                context: LoggingContext) -> EventLoopFuture<StripeValueList> {
         return create(alias: alias,
                           name: name,
                           itemType: itemType,
                           metadata: metadata)
     }
     
-    func retrieve(valueList: String) -> EventLoopFuture<StripeValueList> {
+    func retrieve(valueList: String, context: LoggingContext) -> EventLoopFuture<StripeValueList> {
         return retrieve(valueList: valueList)
     }
     
     func update(valueList: String,
                 alias: String? = nil,
                 metadata: [String: String]? = nil,
-                name: String? = nil) -> EventLoopFuture<StripeValueList> {
+                name: String? = nil,
+                context: LoggingContext) -> EventLoopFuture<StripeValueList> {
         return update(valueList: valueList,
                           alias: alias,
                           metadata: metadata,
                           name: name)
     }
     
-    func delete(valueList: String) -> EventLoopFuture<StripeDeletedObject> {
+    func delete(valueList: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
         return delete(valueList: valueList)
     }
     
-    func listAll(filter: [String: Any]? = nil) -> EventLoopFuture<StripeValueListList> {
+    func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeValueListList> {
         return listAll(filter: filter)
     }
 }
@@ -98,7 +101,8 @@ public struct StripeValueListRoutes: ValueListRoutes {
     public func create(alias: String,
                        name: String,
                        itemType: StripeValueListItemType?,
-                       metadata: [String: String]?) -> EventLoopFuture<StripeValueList> {
+                       metadata: [String: String]?,
+                       context: LoggingContext) -> EventLoopFuture<StripeValueList> {
         var body: [String: Any] = ["alias": alias,
                                    "name": name]
         
@@ -113,14 +117,15 @@ public struct StripeValueListRoutes: ValueListRoutes {
         return apiHandler.send(method: .POST, path: valuelists, body: .string(body.queryParameters), headers: headers)
     }
     
-    public func retrieve(valueList: String) -> EventLoopFuture<StripeValueList> {
+    public func retrieve(valueList: String, context: LoggingContext) -> EventLoopFuture<StripeValueList> {
         return apiHandler.send(method: .GET, path: "\(valuelists)/\(valueList)", headers: headers)
     }
     
     public func update(valueList: String,
                        alias: String?,
                        metadata: [String: String]?,
-                       name: String?) -> EventLoopFuture<StripeValueList> {
+                       name: String?,
+                       context: LoggingContext) -> EventLoopFuture<StripeValueList> {
         var body: [String: Any] = [:]
         
         if let alias = alias {
@@ -138,11 +143,11 @@ public struct StripeValueListRoutes: ValueListRoutes {
         return apiHandler.send(method: .POST, path: "\(valuelists)/\(valueList)", body: .string(body.queryParameters), headers: headers)
     }
     
-    public func delete(valueList: String) -> EventLoopFuture<StripeDeletedObject> {
+    public func delete(valueList: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
         return apiHandler.send(method: .DELETE, path: "\(valuelists)/\(valueList)", headers: headers)
     }
     
-    public func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeValueListList> {
+    public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeValueListList> {
         var queryParams = ""
         if let filter = filter {
             queryParams = filter.queryParameters

--- a/Sources/StripeKit/Issuing/Authorizations/AuthorizationRoutes.swift
+++ b/Sources/StripeKit/Issuing/Authorizations/AuthorizationRoutes.swift
@@ -7,6 +7,7 @@
 
 import NIO
 import NIOHTTP1
+import Baggage
 
 public protocol AuthorizationRoutes {
     /// Retrieves an Issuing Authorization object.
@@ -14,7 +15,7 @@ public protocol AuthorizationRoutes {
     /// - Parameter authorization: The ID of the authorization to retrieve.
     /// - Parameter expand: An array of properties to expand.
     /// - Returns: A `StripeAuthorization`.
-    func retrieve(authorization: String, expand: [String]?) -> EventLoopFuture<StripeAuthorization>
+    func retrieve(authorization: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeAuthorization>
     
     /// Updates the specified Issuing `Authorization` object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
     ///
@@ -23,7 +24,7 @@ public protocol AuthorizationRoutes {
     ///   - metadata: Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
     ///   - expand: An array of properties to expand.
     /// - Returns: A `StripeAuthorization`.
-    func update(authorization: String, metadata: [String: String]?, expand: [String]?) -> EventLoopFuture<StripeAuthorization>
+    func update(authorization: String, metadata: [String: String]?, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeAuthorization>
     
     /// Approves a pending Issuing Authorization object.
     ///
@@ -36,7 +37,8 @@ public protocol AuthorizationRoutes {
     func approve(authorization: String,
                  heldAmount: Int?,
                  metadata: [String: String]?,
-                 expand: [String]?) -> EventLoopFuture<StripeAuthorization>
+                 expand: [String]?,
+                 context: LoggingContext) -> EventLoopFuture<StripeAuthorization>
     
     /// Declines a pending Issuing Authorization object.
     ///
@@ -44,42 +46,43 @@ public protocol AuthorizationRoutes {
     /// - Parameter metadata: Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
     /// - Parameter expand: An array of properties to expand.
     /// - Returns: A `StripeAuthorization`
-    func decline(authorization: String, metadata: [String: String]?, expand: [String]?) -> EventLoopFuture<StripeAuthorization>
+    func decline(authorization: String, metadata: [String: String]?, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeAuthorization>
     
     /// Returns a list of Issuing Authorization objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.
     ///
     /// - Parameter filter:  A dictionary that will be used for the query parameters. [See More →](https://stripe.com/docs/api/issuing/authorizations/list).
     /// - Returns: A `StripeAuthorizationList`.
-    func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeAuthorizationList>
+    func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeAuthorizationList>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
 }
 
 extension AuthorizationRoutes {
-    func retrieve(authorization: String, expand: [String]? = nil) -> EventLoopFuture<StripeAuthorization> {
+    func retrieve(authorization: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeAuthorization> {
         return retrieve(authorization: authorization, expand: expand)
     }
     
-    func update(authorization: String, metadata: [String: String]? = nil, expand: [String]? = nil) -> EventLoopFuture<StripeAuthorization> {
+    func update(authorization: String, metadata: [String: String]? = nil, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeAuthorization> {
         return update(authorization: authorization, metadata: metadata, expand: expand)
     }
     
     func approve(authorization: String,
                  heldAmount: Int? = nil,
                  metadata: [String: String]? = nil,
-                 expand: [String]? = nil) -> EventLoopFuture<StripeAuthorization> {
+                 expand: [String]? = nil,
+                 context: LoggingContext) -> EventLoopFuture<StripeAuthorization> {
         return approve(authorization: authorization,
                        heldAmount: heldAmount,
                        metadata: metadata,
                        expand: expand)
     }
     
-    func decline(authorization: String, metadata: [String: String]? = nil, expand: [String]? = nil) -> EventLoopFuture<StripeAuthorization> {
+    func decline(authorization: String, metadata: [String: String]? = nil, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeAuthorization> {
         return decline(authorization: authorization, metadata: metadata, expand: expand)
     }
     
-    func listAll(filter: [String: Any]? = nil) -> EventLoopFuture<StripeAuthorizationList> {
+    func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeAuthorizationList> {
         return listAll(filter: filter)
     }
 }
@@ -94,7 +97,7 @@ public struct StripeAuthorizationRoutes: AuthorizationRoutes {
         self.apiHandler = apiHandler
     }
     
-    public func retrieve(authorization: String, expand: [String]?) -> EventLoopFuture<StripeAuthorization> {
+    public func retrieve(authorization: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeAuthorization> {
         var queryParams = ""
         if let expand = expand {
             queryParams = ["expand": expand].queryParameters
@@ -103,7 +106,7 @@ public struct StripeAuthorizationRoutes: AuthorizationRoutes {
         return apiHandler.send(method: .GET, path: "\(authorizations)/\(authorization)", query: queryParams, headers: headers)
     }
     
-    public func update(authorization: String, metadata: [String: String]?, expand: [String]?) -> EventLoopFuture<StripeAuthorization> {
+    public func update(authorization: String, metadata: [String: String]?, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeAuthorization> {
         var body: [String: Any] = [:]
         
         if let metadata = metadata {
@@ -117,7 +120,7 @@ public struct StripeAuthorizationRoutes: AuthorizationRoutes {
         return apiHandler.send(method: .POST, path: "\(authorizations)/\(authorization)", body: .string(body.queryParameters), headers: headers)
     }
     
-    public func approve(authorization: String, heldAmount: Int?, metadata: [String: String]?, expand: [String]?) -> EventLoopFuture<StripeAuthorization> {
+    public func approve(authorization: String, heldAmount: Int?, metadata: [String: String]?, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeAuthorization> {
         var body: [String: Any] = [:]
         
         if let heldAmount = heldAmount {
@@ -135,7 +138,7 @@ public struct StripeAuthorizationRoutes: AuthorizationRoutes {
         return apiHandler.send(method: .POST, path: "\(authorizations)/\(authorization)/approve", body: .string(body.queryParameters), headers: headers)
     }
     
-    public func decline(authorization: String, metadata: [String: String]?, expand: [String]?) -> EventLoopFuture<StripeAuthorization> {
+    public func decline(authorization: String, metadata: [String: String]?, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeAuthorization> {
         var body: [String: Any] = [:]
         
         if let metadata = metadata {
@@ -149,7 +152,7 @@ public struct StripeAuthorizationRoutes: AuthorizationRoutes {
         return apiHandler.send(method: .POST, path: "\(authorizations)/\(authorization)/decline", body: .string(body.queryParameters), headers: headers)
     }
     
-    public func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeAuthorizationList> {
+    public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeAuthorizationList> {
         var queryParams = ""
         if let filter = filter {
             queryParams = filter.queryParameters

--- a/Sources/StripeKit/Issuing/Authorizations/AuthorizationRoutes.swift
+++ b/Sources/StripeKit/Issuing/Authorizations/AuthorizationRoutes.swift
@@ -60,11 +60,11 @@ public protocol AuthorizationRoutes {
 
 extension AuthorizationRoutes {
     func retrieve(authorization: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeAuthorization> {
-        return retrieve(authorization: authorization, expand: expand)
+        return retrieve(authorization: authorization, expand: expand, context: context)
     }
     
     func update(authorization: String, metadata: [String: String]? = nil, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeAuthorization> {
-        return update(authorization: authorization, metadata: metadata, expand: expand)
+        return update(authorization: authorization, metadata: metadata, expand: expand, context: context)
     }
     
     func approve(authorization: String,
@@ -75,15 +75,15 @@ extension AuthorizationRoutes {
         return approve(authorization: authorization,
                        heldAmount: heldAmount,
                        metadata: metadata,
-                       expand: expand)
+                       expand: expand, context: context)
     }
     
     func decline(authorization: String, metadata: [String: String]? = nil, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeAuthorization> {
-        return decline(authorization: authorization, metadata: metadata, expand: expand)
+        return decline(authorization: authorization, metadata: metadata, expand: expand, context: context)
     }
     
     func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeAuthorizationList> {
-        return listAll(filter: filter)
+        return listAll(filter: filter, context: context)
     }
 }
 
@@ -103,7 +103,7 @@ public struct StripeAuthorizationRoutes: AuthorizationRoutes {
             queryParams = ["expand": expand].queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: "\(authorizations)/\(authorization)", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(authorizations)/\(authorization)", query: queryParams, headers: headers, context: context)
     }
     
     public func update(authorization: String, metadata: [String: String]?, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeAuthorization> {
@@ -117,7 +117,7 @@ public struct StripeAuthorizationRoutes: AuthorizationRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(authorizations)/\(authorization)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(authorizations)/\(authorization)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func approve(authorization: String, heldAmount: Int?, metadata: [String: String]?, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeAuthorization> {
@@ -135,7 +135,7 @@ public struct StripeAuthorizationRoutes: AuthorizationRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(authorizations)/\(authorization)/approve", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(authorizations)/\(authorization)/approve", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func decline(authorization: String, metadata: [String: String]?, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeAuthorization> {
@@ -149,7 +149,7 @@ public struct StripeAuthorizationRoutes: AuthorizationRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(authorizations)/\(authorization)/decline", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(authorizations)/\(authorization)/decline", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeAuthorizationList> {
@@ -158,6 +158,6 @@ public struct StripeAuthorizationRoutes: AuthorizationRoutes {
             queryParams = filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: authorizations, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: authorizations, query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Issuing/Card/IssuingCardRoutes.swift
+++ b/Sources/StripeKit/Issuing/Card/IssuingCardRoutes.swift
@@ -7,6 +7,7 @@
 
 import NIO
 import NIOHTTP1
+import Baggage
 
 public protocol IssuingCardRoutes {
     /// Creates an Issuing `Card` object.
@@ -32,14 +33,15 @@ public protocol IssuingCardRoutes {
                 replacementReason: StripeIssuingCardReplacementReason?,
                 shipping: [String: Any]?,
                 status: StripeIssuingCardStatus?,
-                expand: [String]?) -> EventLoopFuture<StripeIssuingCard>
+                expand: [String]?,
+                context: LoggingContext) -> EventLoopFuture<StripeIssuingCard>
     
     /// Retrieves an Issuing `Card` object.
     ///
     /// - Parameter card: The identifier of the card to be retrieved.
     /// - Parameter expand: An array of properties to expand.
     /// - Returns: A `StripeIssuingCard`.
-    func retrieve(card: String, expand: [String]?) -> EventLoopFuture<StripeIssuingCard>
+    func retrieve(card: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeIssuingCard>
     
     /// Updates the specified Issuing Card object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
     ///
@@ -56,13 +58,14 @@ public protocol IssuingCardRoutes {
                 cancellationReason: StripeIssuingCardCancellationReason?,
                 metadata: [String: String]?,
                 status: StripeIssuingCardStatus?,
-                expand: [String]?) -> EventLoopFuture<StripeIssuingCard>
+                expand: [String]?,
+                context: LoggingContext) -> EventLoopFuture<StripeIssuingCard>
     
     /// Returns a list of Issuing Card objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.
     ///
     /// - Parameter filter:  A dictionary that will be used for the query parameters. [See More →](https://stripe.com/docs/api/issuing/cards/list).
     /// - Returns: A `StripeIssuingCardList`.
-    func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeIssuingCardList>
+    func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeIssuingCardList>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
@@ -78,7 +81,8 @@ extension IssuingCardRoutes {
                 replacementReason: StripeIssuingCardReplacementReason? = nil,
                 shipping: [String: Any]? = nil,
                 status: StripeIssuingCardStatus? = nil,
-                expand: [String]? = nil) -> EventLoopFuture<StripeIssuingCard> {
+                expand: [String]? = nil,
+                context: LoggingContext) -> EventLoopFuture<StripeIssuingCard> {
         return create(cardholder: cardholder,
                       currency: currency,
                       type: type,
@@ -91,7 +95,7 @@ extension IssuingCardRoutes {
                       expand: expand)
     }
     
-    func retrieve(card: String, expand: [String]? = nil) -> EventLoopFuture<StripeIssuingCard> {
+    func retrieve(card: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeIssuingCard> {
         return retrieve(card: card, expand: expand)
     }
     
@@ -100,7 +104,8 @@ extension IssuingCardRoutes {
                 cancellationReason: StripeIssuingCardCancellationReason? = nil,
                 metadata: [String: String]? = nil,
                 status: StripeIssuingCardStatus? = nil,
-                expand: [String]? = nil) -> EventLoopFuture<StripeIssuingCard> {
+                expand: [String]? = nil,
+                context: LoggingContext) -> EventLoopFuture<StripeIssuingCard> {
         return update(card: card,
                       spendingControls: spendingControls,
                       cancellationReason: cancellationReason,
@@ -109,7 +114,7 @@ extension IssuingCardRoutes {
                       expand: expand)
     }
     
-    func listAll(filter: [String: Any]? = nil) -> EventLoopFuture<StripeIssuingCardList> {
+    func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeIssuingCardList> {
         return listAll(filter: filter)
     }
 }
@@ -133,7 +138,8 @@ public struct StripeIssuingCardRoutes: IssuingCardRoutes {
                        replacementReason: StripeIssuingCardReplacementReason?,
                        shipping: [String: Any]?,
                        status: StripeIssuingCardStatus?,
-                       expand: [String]?) -> EventLoopFuture<StripeIssuingCard> {
+                       expand: [String]?,
+                       context: LoggingContext) -> EventLoopFuture<StripeIssuingCard> {
         var body: [String: Any] = ["cardholder": cardholder,
                                    "currency": currency.rawValue,
                                    "type": type.rawValue]
@@ -169,7 +175,7 @@ public struct StripeIssuingCardRoutes: IssuingCardRoutes {
         return apiHandler.send(method: .POST, path: issuingcards, body: .string(body.queryParameters), headers: headers)
     }
     
-    public func retrieve(card: String, expand: [String]?) -> EventLoopFuture<StripeIssuingCard> {
+    public func retrieve(card: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeIssuingCard> {
         var queryParams = ""
         if let expand = expand {
             queryParams = ["expand": expand].queryParameters
@@ -183,7 +189,8 @@ public struct StripeIssuingCardRoutes: IssuingCardRoutes {
                        cancellationReason: StripeIssuingCardCancellationReason?,
                        metadata: [String: String]?,
                        status: StripeIssuingCardStatus?,
-                       expand: [String]?) -> EventLoopFuture<StripeIssuingCard> {
+                       expand: [String]?,
+                       context: LoggingContext) -> EventLoopFuture<StripeIssuingCard> {
         var body: [String: Any] = [:]
         
         if let spendingControls = spendingControls {
@@ -209,7 +216,7 @@ public struct StripeIssuingCardRoutes: IssuingCardRoutes {
         return apiHandler.send(method: .POST, path: "\(issuingcards)/\(card)", body: .string(body.queryParameters), headers: headers)
     }
     
-    public func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeIssuingCardList> {
+    public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeIssuingCardList> {
         var queryParams = ""
         if let filter = filter {
             queryParams = filter.queryParameters

--- a/Sources/StripeKit/Issuing/Card/IssuingCardRoutes.swift
+++ b/Sources/StripeKit/Issuing/Card/IssuingCardRoutes.swift
@@ -92,11 +92,12 @@ extension IssuingCardRoutes {
                       replacementReason: replacementReason,
                       shipping: shipping,
                       status: status,
-                      expand: expand)
+                      expand: expand,
+                      context: context)
     }
     
     func retrieve(card: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeIssuingCard> {
-        return retrieve(card: card, expand: expand)
+        return retrieve(card: card, expand: expand, context: context)
     }
     
     func update(card: String,
@@ -111,11 +112,12 @@ extension IssuingCardRoutes {
                       cancellationReason: cancellationReason,
                       metadata: metadata,
                       status: status,
-                      expand: expand)
+                      expand: expand,
+                      context: context)
     }
     
     func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeIssuingCardList> {
-        return listAll(filter: filter)
+        return listAll(filter: filter, context: context)
     }
 }
 
@@ -172,7 +174,7 @@ public struct StripeIssuingCardRoutes: IssuingCardRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: issuingcards, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: issuingcards, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(card: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeIssuingCard> {
@@ -181,7 +183,7 @@ public struct StripeIssuingCardRoutes: IssuingCardRoutes {
             queryParams = ["expand": expand].queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: "\(issuingcards)/\(card)", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(issuingcards)/\(card)", query: queryParams, headers: headers, context: context)
     }
 
     public func update(card: String,
@@ -213,7 +215,7 @@ public struct StripeIssuingCardRoutes: IssuingCardRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(issuingcards)/\(card)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(issuingcards)/\(card)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeIssuingCardList> {
@@ -222,6 +224,6 @@ public struct StripeIssuingCardRoutes: IssuingCardRoutes {
             queryParams = filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: issuingcards, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: issuingcards, query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Issuing/Cardholders/CardholderRoutes.swift
+++ b/Sources/StripeKit/Issuing/Cardholders/CardholderRoutes.swift
@@ -103,11 +103,12 @@ extension CardholderRoutes {
                       isDefault: isDefault,
                       metadata: metadata,
                       phoneNumber: phoneNumber,
-                      status: status)
+                      status: status,
+                      context: context)
     }
     
     func retrieve(cardholder: String, context: LoggingContext) -> EventLoopFuture<StripeCardholder> {
-        return retrieve(cardholder: cardholder)
+        return retrieve(cardholder: cardholder, context: context)
     }
     
     func update(cardholder: String,
@@ -130,11 +131,12 @@ extension CardholderRoutes {
                       isDefault: isDefault,
                       metadata: metadata,
                       phoneNumber: phoneNumber,
-                      status: status)
+                      status: status,
+                      context: context)
     }
     
     func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeAuthorizationList> {
-        return listAll(filter: filter)
+        return listAll(filter: filter, context: context)
     }
 }
 
@@ -196,11 +198,11 @@ public struct StripeCardholderRoutes: CardholderRoutes {
             body["status"] = status.rawValue
         }
         
-        return apiHandler.send(method: .POST, path: cardholders, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: cardholders, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(cardholder: String, context: LoggingContext) -> EventLoopFuture<StripeCardholder> {
-        return apiHandler.send(method: .GET, path: "\(cardholders)/\(cardholder)", headers: headers)
+        return apiHandler.send(method: .GET, path: "\(cardholders)/\(cardholder)", headers: headers, context: context)
     }
     
     public func update(cardholder: String,
@@ -252,7 +254,7 @@ public struct StripeCardholderRoutes: CardholderRoutes {
             body["status"] = status.rawValue
         }
         
-        return apiHandler.send(method: .POST, path: "\(cardholders)/\(cardholder)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(cardholders)/\(cardholder)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func listAll(filter: [String : Any]?, context: LoggingContext) -> EventLoopFuture<StripeAuthorizationList> {
@@ -261,6 +263,6 @@ public struct StripeCardholderRoutes: CardholderRoutes {
             queryParams = filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: cardholders, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: cardholders, query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Issuing/Cardholders/CardholderRoutes.swift
+++ b/Sources/StripeKit/Issuing/Cardholders/CardholderRoutes.swift
@@ -7,6 +7,7 @@
 
 import NIO
 import NIOHTTP1
+import Baggage
 
 public protocol CardholderRoutes {
     /// Creates a new Issuing Cardholder object that can be issued cards.
@@ -34,13 +35,14 @@ public protocol CardholderRoutes {
                 isDefault: Bool?,
                 metadata: [String: String]?,
                 phoneNumber: String?,
-                status: StripeCardholderStatus?) -> EventLoopFuture<StripeCardholder>
+                status: StripeCardholderStatus?,
+                context: LoggingContext) -> EventLoopFuture<StripeCardholder>
     
     /// Retrieves an Issuing Cardholder object.
     ///
     /// - Parameter cardholder: The identifier of the cardholder to be retrieved.
     /// - Returns: A `StripeCardholder`.
-    func retrieve(cardholder: String) -> EventLoopFuture<StripeCardholder>
+    func retrieve(cardholder: String, context: LoggingContext) -> EventLoopFuture<StripeCardholder>
     
     /// Updates the specified Issuing Cardholder object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
     ///
@@ -65,13 +67,14 @@ public protocol CardholderRoutes {
                 isDefault: Bool?,
                 metadata: [String: String]?,
                 phoneNumber: String?,
-                status: StripeCardholderStatus?) -> EventLoopFuture<StripeCardholder>
+                status: StripeCardholderStatus?,
+                context: LoggingContext) -> EventLoopFuture<StripeCardholder>
     
     /// Returns a list of Issuing Cardholder objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.
     ///
     /// - Parameter filter:  A dictionary that will be used for the query parameters. [See More →](https://stripe.com/docs/api/issuing/cardholders/list).
     /// - Returns: A `StripeAuthorizationList`.
-    func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeAuthorizationList>
+    func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeAuthorizationList>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
@@ -88,7 +91,8 @@ extension CardholderRoutes {
                 isDefault: Bool? = nil,
                 metadata: [String: String]? = nil,
                 phoneNumber: String? = nil,
-                status: StripeCardholderStatus? = nil) -> EventLoopFuture<StripeCardholder> {
+                status: StripeCardholderStatus? = nil,
+                context: LoggingContext) -> EventLoopFuture<StripeCardholder> {
         return create(billing: billing,
                       name: name,
                       type: type,
@@ -102,7 +106,7 @@ extension CardholderRoutes {
                       status: status)
     }
     
-    func retrieve(cardholder: String) -> EventLoopFuture<StripeCardholder> {
+    func retrieve(cardholder: String, context: LoggingContext) -> EventLoopFuture<StripeCardholder> {
         return retrieve(cardholder: cardholder)
     }
     
@@ -115,7 +119,8 @@ extension CardholderRoutes {
                 isDefault: Bool? = nil,
                 metadata: [String: String]? = nil,
                 phoneNumber: String? = nil,
-                status: StripeCardholderStatus? = nil) -> EventLoopFuture<StripeCardholder> {
+                status: StripeCardholderStatus? = nil,
+                context: LoggingContext) -> EventLoopFuture<StripeCardholder> {
         return update(cardholder: cardholder,
                       authorizationControls: authorizationControls,
                       billing: billing,
@@ -128,7 +133,7 @@ extension CardholderRoutes {
                       status: status)
     }
     
-    func listAll(filter: [String: Any]? = nil) -> EventLoopFuture<StripeAuthorizationList> {
+    func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeAuthorizationList> {
         return listAll(filter: filter)
     }
 }
@@ -153,7 +158,8 @@ public struct StripeCardholderRoutes: CardholderRoutes {
                        isDefault: Bool?,
                        metadata: [String: String]?,
                        phoneNumber: String?,
-                       status: StripeCardholderStatus?) -> EventLoopFuture<StripeCardholder> {
+                       status: StripeCardholderStatus?,
+                       context: LoggingContext) -> EventLoopFuture<StripeCardholder> {
         var body: [String: Any] = ["name": name,
                                    "type": type.rawValue]
         billing.forEach { body["billing[\($0)]"] = $1 }
@@ -193,7 +199,7 @@ public struct StripeCardholderRoutes: CardholderRoutes {
         return apiHandler.send(method: .POST, path: cardholders, body: .string(body.queryParameters), headers: headers)
     }
     
-    public func retrieve(cardholder: String) -> EventLoopFuture<StripeCardholder> {
+    public func retrieve(cardholder: String, context: LoggingContext) -> EventLoopFuture<StripeCardholder> {
         return apiHandler.send(method: .GET, path: "\(cardholders)/\(cardholder)", headers: headers)
     }
     
@@ -206,7 +212,8 @@ public struct StripeCardholderRoutes: CardholderRoutes {
                        isDefault: Bool?,
                        metadata: [String: String]?,
                        phoneNumber: String?,
-                       status: StripeCardholderStatus?) -> EventLoopFuture<StripeCardholder> {
+                       status: StripeCardholderStatus?,
+                       context: LoggingContext) -> EventLoopFuture<StripeCardholder> {
         var body: [String: Any] = [:]
         
         if let authorizationControls = authorizationControls {
@@ -248,7 +255,7 @@ public struct StripeCardholderRoutes: CardholderRoutes {
         return apiHandler.send(method: .POST, path: "\(cardholders)/\(cardholder)", body: .string(body.queryParameters), headers: headers)
     }
     
-    public func listAll(filter: [String : Any]?) -> EventLoopFuture<StripeAuthorizationList> {
+    public func listAll(filter: [String : Any]?, context: LoggingContext) -> EventLoopFuture<StripeAuthorizationList> {
         var queryParams = ""
         if let filter = filter {
             queryParams = filter.queryParameters

--- a/Sources/StripeKit/Issuing/Disputes/IssuingDisputeRoutes.swift
+++ b/Sources/StripeKit/Issuing/Disputes/IssuingDisputeRoutes.swift
@@ -7,6 +7,7 @@
 
 import NIO
 import NIOHTTP1
+import Baggage
 
 public protocol IssuingDisputeRoutes {
     /// Creates an Issuing Dispute object.
@@ -22,13 +23,14 @@ public protocol IssuingDisputeRoutes {
                 reason: StripeIssuingDisputeReason,
                 amount: Int?,
                 evidence: [String: Any]?,
-                metadata: [String: String]?) -> EventLoopFuture<StripeIssuingDispute>
+                metadata: [String: String]?,
+                context: LoggingContext) -> EventLoopFuture<StripeIssuingDispute>
     
     /// Retrieves an Issuing Dispute object.
     ///
     /// - Parameter dispute: The ID of the dispute to retrieve.
     /// - Returns: A `StripeIssuingDispute`.
-    func retrieve(dispute: String) -> EventLoopFuture<StripeIssuingDispute>
+    func retrieve(dispute: String, context: LoggingContext) -> EventLoopFuture<StripeIssuingDispute>
     
     /// Updates the specified Issuing Dispute object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
     ///
@@ -36,13 +38,13 @@ public protocol IssuingDisputeRoutes {
     ///   - dispute: The ID of the dispute to update.
     ///   - metadata: Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to metadata.
     /// - Returns: A `StripeIssuingDispute`.
-    func update(dispute: String, metadata: [String: String]?) -> EventLoopFuture<StripeIssuingDispute>
+    func update(dispute: String, metadata: [String: String]?, context: LoggingContext) -> EventLoopFuture<StripeIssuingDispute>
     
     /// Returns a list of Issuing Dispute objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.
     ///
     /// - Parameter filter: A dictionary that will be used for the query parameters. [See More →](https://stripe.com/docs/api/issuing/disputes/list).
     /// - Returns: A `StripeIssuingDisputeList`.
-    func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeIssuingDisputeList>
+    func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeIssuingDisputeList>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
@@ -53,7 +55,8 @@ extension IssuingDisputeRoutes {
                 reason: StripeIssuingDisputeReason,
                 amount: Int? = nil,
                 evidence: [String: Any]? = nil,
-                metadata: [String: String]? = nil) -> EventLoopFuture<StripeIssuingDispute> {
+                metadata: [String: String]? = nil,
+                context: LoggingContext) -> EventLoopFuture<StripeIssuingDispute> {
         return create(disputedTransaction: disputedTransaction,
                           reason: reason,
                           amount: amount,
@@ -61,15 +64,15 @@ extension IssuingDisputeRoutes {
                           metadata: metadata)
     }
     
-    func retrieve(dispute: String) -> EventLoopFuture<StripeIssuingDispute> {
+    func retrieve(dispute: String, context: LoggingContext) -> EventLoopFuture<StripeIssuingDispute> {
         return retrieve(dispute: dispute)
     }
     
-    func update(dispute: String, metadata: [String: String]? = nil) -> EventLoopFuture<StripeIssuingDispute> {
+    func update(dispute: String, metadata: [String: String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeIssuingDispute> {
         return update(dispute: dispute, metadata: metadata)
     }
     
-    func listAll(filter: [String: Any]? = nil) -> EventLoopFuture<StripeIssuingDisputeList> {
+    func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeIssuingDisputeList> {
         return listAll(filter: filter)
     }
 }
@@ -88,7 +91,8 @@ public struct StripeIssuingDisputeRoutes: IssuingDisputeRoutes {
                        reason: StripeIssuingDisputeReason,
                        amount: Int?,
                        evidence: [String: Any]?,
-                       metadata: [String: String]?) -> EventLoopFuture<StripeIssuingDispute> {
+                       metadata: [String: String]?,
+                       context: LoggingContext) -> EventLoopFuture<StripeIssuingDispute> {
         var body: [String: Any] = ["disputed_transaction": disputedTransaction,
                                    "reason": reason.rawValue]
         
@@ -107,11 +111,11 @@ public struct StripeIssuingDisputeRoutes: IssuingDisputeRoutes {
         return apiHandler.send(method: .POST, path: issuingdisputes, body: .string(body.queryParameters), headers: headers)
     }
     
-    public func retrieve(dispute: String) -> EventLoopFuture<StripeIssuingDispute> {
+    public func retrieve(dispute: String, context: LoggingContext) -> EventLoopFuture<StripeIssuingDispute> {
         return apiHandler.send(method: .GET, path: "\(issuingdisputes)/\(dispute)", headers: headers)
     }
     
-    public func update(dispute: String, metadata: [String: String]?) -> EventLoopFuture<StripeIssuingDispute> {
+    public func update(dispute: String, metadata: [String: String]?, context: LoggingContext) -> EventLoopFuture<StripeIssuingDispute> {
         var body: [String: Any] = [:]
         
         if let metadata = metadata {
@@ -121,7 +125,7 @@ public struct StripeIssuingDisputeRoutes: IssuingDisputeRoutes {
         return apiHandler.send(method: .POST, path: "\(issuingdisputes)/\(dispute)", body: .string(body.queryParameters), headers: headers)
     }
     
-    public func listAll(filter: [String : Any]? = nil) -> EventLoopFuture<StripeIssuingDisputeList> {
+    public func listAll(filter: [String : Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeIssuingDisputeList> {
         var queryParams = ""
         if let filter = filter {
             queryParams = filter.queryParameters

--- a/Sources/StripeKit/Issuing/Disputes/IssuingDisputeRoutes.swift
+++ b/Sources/StripeKit/Issuing/Disputes/IssuingDisputeRoutes.swift
@@ -61,19 +61,20 @@ extension IssuingDisputeRoutes {
                           reason: reason,
                           amount: amount,
                           evidence: evidence,
-                          metadata: metadata)
+                          metadata: metadata,
+                      context: context)
     }
     
     func retrieve(dispute: String, context: LoggingContext) -> EventLoopFuture<StripeIssuingDispute> {
-        return retrieve(dispute: dispute)
+        return retrieve(dispute: dispute, context: context)
     }
     
     func update(dispute: String, metadata: [String: String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeIssuingDispute> {
-        return update(dispute: dispute, metadata: metadata)
+        return update(dispute: dispute, metadata: metadata, context: context)
     }
     
     func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeIssuingDisputeList> {
-        return listAll(filter: filter)
+        return listAll(filter: filter, context: context)
     }
 }
 
@@ -108,11 +109,11 @@ public struct StripeIssuingDisputeRoutes: IssuingDisputeRoutes {
             metadata.forEach { body["metadata[\($0)]"] = $1 }
         }
         
-        return apiHandler.send(method: .POST, path: issuingdisputes, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: issuingdisputes, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(dispute: String, context: LoggingContext) -> EventLoopFuture<StripeIssuingDispute> {
-        return apiHandler.send(method: .GET, path: "\(issuingdisputes)/\(dispute)", headers: headers)
+        return apiHandler.send(method: .GET, path: "\(issuingdisputes)/\(dispute)", headers: headers, context: context)
     }
     
     public func update(dispute: String, metadata: [String: String]?, context: LoggingContext) -> EventLoopFuture<StripeIssuingDispute> {
@@ -122,7 +123,7 @@ public struct StripeIssuingDisputeRoutes: IssuingDisputeRoutes {
             metadata.forEach { body["metadata[\($0)]"] = $1 }
         }
         
-        return apiHandler.send(method: .POST, path: "\(issuingdisputes)/\(dispute)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(issuingdisputes)/\(dispute)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func listAll(filter: [String : Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeIssuingDisputeList> {
@@ -131,6 +132,6 @@ public struct StripeIssuingDisputeRoutes: IssuingDisputeRoutes {
             queryParams = filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: issuingdisputes, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: issuingdisputes, query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Issuing/Transactions/TransactionRoutes.swift
+++ b/Sources/StripeKit/Issuing/Transactions/TransactionRoutes.swift
@@ -38,15 +38,15 @@ public protocol TransactionRoutes {
 
 extension TransactionRoutes {
     func retrieve(transaction: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeTransaction> {
-        return retrieve(transaction: transaction, expand: expand)
+        return retrieve(transaction: transaction, expand: expand, context: context)
     }
     
     func update(transaction: String, metadata: [String: String]? = nil, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeTransaction> {
-        return update(transaction: transaction, metadata: metadata, expand: expand)
+        return update(transaction: transaction, metadata: metadata, expand: expand, context: context)
     }
     
     func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeTransactionList> {
-        return listAll(filter: filter)
+        return listAll(filter: filter, context: context)
     }
 }
 
@@ -65,7 +65,7 @@ public struct StripeTransactionRoutes: TransactionRoutes {
         if let expand = expand {
             queryParams = ["expand": expand].queryParameters
         }
-        return apiHandler.send(method: .GET, path: "\(issuingtransactions)/\(transaction)", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(issuingtransactions)/\(transaction)", query: queryParams, headers: headers, context: context)
     }
     
     public func update(transaction: String, metadata: [String: String]?, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeTransaction> {
@@ -79,7 +79,7 @@ public struct StripeTransactionRoutes: TransactionRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(issuingtransactions)/\(transaction)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(issuingtransactions)/\(transaction)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeTransactionList> {
@@ -88,6 +88,6 @@ public struct StripeTransactionRoutes: TransactionRoutes {
             queryParams = filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: issuingtransactions, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: issuingtransactions, query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Issuing/Transactions/TransactionRoutes.swift
+++ b/Sources/StripeKit/Issuing/Transactions/TransactionRoutes.swift
@@ -7,6 +7,7 @@
 
 import NIO
 import NIOHTTP1
+import Baggage
 
 public protocol TransactionRoutes {
     /// Retrieves an Issuing Transaction object.
@@ -14,7 +15,7 @@ public protocol TransactionRoutes {
     /// - Parameter transaction: The ID of the transaction to retrieve.
     /// - Parameter expand: An array of properties to expand.
     /// - Returns: A `StripeTransaction`.
-    func retrieve(transaction: String, expand: [String]?) -> EventLoopFuture<StripeTransaction>
+    func retrieve(transaction: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeTransaction>
     
     /// Updates the specified Issuing Transaction object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
     ///
@@ -23,28 +24,28 @@ public protocol TransactionRoutes {
     ///   - metadata: Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
     ///   - expand: An array of properties to expand.
     /// - Returns: A `StripeTransaction`.
-    func update(transaction: String, metadata: [String: String]?, expand: [String]?) -> EventLoopFuture<StripeTransaction>
+    func update(transaction: String, metadata: [String: String]?, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeTransaction>
     
     /// Returns a list of Issuing Transaction objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.
     ///
     /// - Parameter filter: A dictionary that will be used for the query parameters. [See More →](https://stripe.com/docs/api/issuing/transactions/list).
     /// - Returns: A `StripeTransactionList`.
-    func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeTransactionList>
+    func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeTransactionList>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
 }
 
 extension TransactionRoutes {
-    func retrieve(transaction: String, expand: [String]? = nil) -> EventLoopFuture<StripeTransaction> {
+    func retrieve(transaction: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeTransaction> {
         return retrieve(transaction: transaction, expand: expand)
     }
     
-    func update(transaction: String, metadata: [String: String]? = nil, expand: [String]? = nil) -> EventLoopFuture<StripeTransaction> {
+    func update(transaction: String, metadata: [String: String]? = nil, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeTransaction> {
         return update(transaction: transaction, metadata: metadata, expand: expand)
     }
     
-    func listAll(filter: [String: Any]? = nil) -> EventLoopFuture<StripeTransactionList> {
+    func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeTransactionList> {
         return listAll(filter: filter)
     }
 }
@@ -59,7 +60,7 @@ public struct StripeTransactionRoutes: TransactionRoutes {
         self.apiHandler = apiHandler
     }
     
-    public func retrieve(transaction: String, expand: [String]?) -> EventLoopFuture<StripeTransaction> {
+    public func retrieve(transaction: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeTransaction> {
         var queryParams = ""
         if let expand = expand {
             queryParams = ["expand": expand].queryParameters
@@ -67,7 +68,7 @@ public struct StripeTransactionRoutes: TransactionRoutes {
         return apiHandler.send(method: .GET, path: "\(issuingtransactions)/\(transaction)", query: queryParams, headers: headers)
     }
     
-    public func update(transaction: String, metadata: [String: String]?, expand: [String]?) -> EventLoopFuture<StripeTransaction> {
+    public func update(transaction: String, metadata: [String: String]?, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeTransaction> {
         var body: [String: Any] = [:]
         
         if let metadata = metadata {
@@ -81,7 +82,7 @@ public struct StripeTransactionRoutes: TransactionRoutes {
         return apiHandler.send(method: .POST, path: "\(issuingtransactions)/\(transaction)", body: .string(body.queryParameters), headers: headers)
     }
     
-    public func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeTransactionList> {
+    public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeTransactionList> {
         var queryParams = ""
         if let filter = filter {
             queryParams = filter.queryParameters

--- a/Sources/StripeKit/Orders/Orders/OrderRoutes.swift
+++ b/Sources/StripeKit/Orders/Orders/OrderRoutes.swift
@@ -117,11 +117,12 @@ extension OrderRoutes {
                       items: items,
                       metadata: metadata,
                       shipping: shipping,
-                      expand: expand)
+                      expand: expand,
+                      context: context)
     }
     
     public func retrieve(id: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeOrder> {
-        return retrieve(id: id, expand: expand)
+        return retrieve(id: id, expand: expand, context: context)
     }
     
     public func update(id: String,
@@ -138,7 +139,8 @@ extension OrderRoutes {
                       selectedShippingMethod: selectedShippingMethod,
                       shipping: shipping,
                       status: status,
-                      expand: expand)
+                      expand: expand,
+                      context: context)
     }
     
     public func pay(id: String,
@@ -155,15 +157,16 @@ extension OrderRoutes {
                    applicationFee: applicationFee,
                    email: email,
                    metadata: metadata,
-                   expand: expand)
+                   expand: expand,
+                   context: context)
     }
     
     public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeOrderList> {
-        return listAll(filter: filter)
+        return listAll(filter: filter, context: context)
     }
     
     public func `return`(id: String, items: [[String: Any]]? = nil, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeOrder> {
-        return `return`(id: id, items: items, expand: expand)
+        return `return`(id: id, items: items, expand: expand, context: context)
     }
 }
 
@@ -216,7 +219,7 @@ public struct StripeOrderRoutes: OrderRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: orders, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: orders, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(id: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeOrder> {
@@ -225,7 +228,7 @@ public struct StripeOrderRoutes: OrderRoutes {
             queryParams = ["expand": expand].queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: "\(orders)/\(id)", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(orders)/\(id)", query: queryParams, headers: headers, context: context)
     }
     
     public func update(id: String,
@@ -262,7 +265,7 @@ public struct StripeOrderRoutes: OrderRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(orders)/\(id)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(orders)/\(id)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func pay(id: String,
@@ -304,7 +307,7 @@ public struct StripeOrderRoutes: OrderRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(orders)/\(id)/pay", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(orders)/\(id)/pay", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeOrderList> {
@@ -313,7 +316,7 @@ public struct StripeOrderRoutes: OrderRoutes {
             queryParams = filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: orders, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: orders, query: queryParams, headers: headers, context: context)
     }
 
     public func `return`(id: String, items: [[String: Any]]?, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeOrder> {
@@ -327,6 +330,6 @@ public struct StripeOrderRoutes: OrderRoutes {
             body["expand"] = expand
         }
 
-        return apiHandler.send(method: .POST, path: "\(orders)/\(id)/returns", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(orders)/\(id)/returns", body: .string(body.queryParameters), headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Orders/Returns/OrderReturnRoutes.swift
+++ b/Sources/StripeKit/Orders/Returns/OrderReturnRoutes.swift
@@ -30,11 +30,11 @@ public protocol OrderReturnRoutes {
 
 extension OrderReturnRoutes {
     public func retrieve(id: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeOrderReturn> {
-        return retrieve(id: id, expand: expand)
+        return retrieve(id: id, expand: expand, context: context)
     }
     
     public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeOrderReturnList> {
-        return listAll(filter: filter)
+        return listAll(filter: filter, context: context)
     }
 }
 
@@ -53,7 +53,7 @@ public struct StripeOrderReturnRoutes: OrderReturnRoutes {
         if let expand = expand {
             queryParams = ["expand": expand].queryParameters
         }
-        return apiHandler.send(method: .GET, path: "\(orderreturns)/\(id)", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(orderreturns)/\(id)", query: queryParams, headers: headers, context: context)
     }
     
     public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeOrderReturnList> {
@@ -62,6 +62,6 @@ public struct StripeOrderReturnRoutes: OrderReturnRoutes {
             queryParams = filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: orderreturns, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: orderreturns, query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Orders/Returns/OrderReturnRoutes.swift
+++ b/Sources/StripeKit/Orders/Returns/OrderReturnRoutes.swift
@@ -8,6 +8,7 @@
 
 import NIO
 import NIOHTTP1
+import Baggage
 
 public protocol OrderReturnRoutes {
     /// Retrieves the details of an existing order return. Supply the unique order ID from either an order return creation request or the order return list, and Stripe will return the corresponding order information.
@@ -15,24 +16,24 @@ public protocol OrderReturnRoutes {
     /// - Parameter id: The identifier of the order return to be retrieved.
     /// - Parameter expand: An array of properties to expand.
     /// - Returns: A `StripeOrderReturn`.
-    func retrieve(id: String, expand: [String]?) -> EventLoopFuture<StripeOrderReturn>
+    func retrieve(id: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeOrderReturn>
     
     /// Returns a list of your order returns. The returns are returned sorted by creation date, with the most recently created return appearing first.
     ///
     /// - Parameter filter: A dictionary that will be used for the query parameters. [See More →](https://stripe.com/docs/api/order_returns/list)
     /// - Returns: A `StripeOrderReturnList`.
-    func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeOrderReturnList>
+    func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeOrderReturnList>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
 }
 
 extension OrderReturnRoutes {
-    public func retrieve(id: String, expand: [String]? = nil) -> EventLoopFuture<StripeOrderReturn> {
+    public func retrieve(id: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeOrderReturn> {
         return retrieve(id: id, expand: expand)
     }
     
-    public func listAll(filter: [String: Any]? = nil) -> EventLoopFuture<StripeOrderReturnList> {
+    public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeOrderReturnList> {
         return listAll(filter: filter)
     }
 }
@@ -47,7 +48,7 @@ public struct StripeOrderReturnRoutes: OrderReturnRoutes {
         self.apiHandler = apiHandler
     }
     
-    public func retrieve(id: String, expand: [String]?) -> EventLoopFuture<StripeOrderReturn> {
+    public func retrieve(id: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeOrderReturn> {
         var queryParams = ""
         if let expand = expand {
             queryParams = ["expand": expand].queryParameters
@@ -55,7 +56,7 @@ public struct StripeOrderReturnRoutes: OrderReturnRoutes {
         return apiHandler.send(method: .GET, path: "\(orderreturns)/\(id)", query: queryParams, headers: headers)
     }
     
-    public func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeOrderReturnList> {
+    public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeOrderReturnList> {
         var queryParams = ""
         if let filter = filter {
             queryParams = filter.queryParameters

--- a/Sources/StripeKit/Orders/SKU/SKURoutes.swift
+++ b/Sources/StripeKit/Orders/SKU/SKURoutes.swift
@@ -115,11 +115,12 @@ extension SKURoutes {
                       image: image,
                       metadata: metadata,
                       packageDimensions: packageDimensions,
-                      expand: expand)
+                      expand: expand,
+                      context: context)
     }
     
     public func retrieve(id: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeSKU> {
-        return retrieve(id: id, expand: expand)
+        return retrieve(id: id, expand: expand, context: context)
     }
     
     public func update(id: String,
@@ -144,15 +145,16 @@ extension SKURoutes {
                       packageDimensions: packageDimensions,
                       price: price,
                       product: product,
-                      expand: expand)
+                      expand: expand,
+                      context: context)
     }
     
     public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeSKUList> {
-        return listAll(filter: filter)
+        return listAll(filter: filter, context: context)
     }
     
     public func delete(id: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
-        return delete(id: id)
+        return delete(id: id, context: context)
     }
 }
 
@@ -208,7 +210,7 @@ public struct StripeSKURoutes: SKURoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: skus, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: skus, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(id: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeSKU> {
@@ -217,7 +219,7 @@ public struct StripeSKURoutes: SKURoutes {
             queryParams = ["expand": expand].queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: "\(skus)/\(id)", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(skus)/\(id)", query: queryParams, headers: headers, context: context)
     }
     
     public func update(id: String,
@@ -270,7 +272,7 @@ public struct StripeSKURoutes: SKURoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(skus)/\(id)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(skus)/\(id)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeSKUList> {
@@ -279,10 +281,10 @@ public struct StripeSKURoutes: SKURoutes {
             queryParams = filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: skus, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: skus, query: queryParams, headers: headers, context: context)
     }
     
     public func delete(id: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
-        return apiHandler.send(method: .DELETE, path: "\(skus)/\(id)", headers: headers)
+        return apiHandler.send(method: .DELETE, path: "\(skus)/\(id)", headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Payment Methods/Bank Accounts/BankAccountRoutes.swift
+++ b/Sources/StripeKit/Payment Methods/Bank Accounts/BankAccountRoutes.swift
@@ -87,11 +87,11 @@ extension BankAccountRoutes {
                        metadata: [String: String]? = nil,
                        expand: [String]? = nil,
                        context: LoggingContext) -> EventLoopFuture<StripeBankAccount> {
-        return create(customer: customer, source: source, metadata: metadata, expand: expand)
+        return create(customer: customer, source: source, metadata: metadata, expand: expand, context: context)
     }
     
     public func retrieve(id: String, customer: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeBankAccount> {
-        return retrieve(id: id, customer: customer, expand: expand)
+        return retrieve(id: id, customer: customer, expand: expand, context: context)
     }
     
     public func update(id: String,
@@ -106,7 +106,8 @@ extension BankAccountRoutes {
                       accountHolderName: accountHolderName,
                       accountHolderType: accountHolderType,
                       metadata: metadata,
-                      expand: expand)
+                      expand: expand,
+                      context: context)
     }
     
     public func verify(id: String,
@@ -114,15 +115,15 @@ extension BankAccountRoutes {
                        amounts: [Int]? = nil,
                        expand: [String]? = nil,
                        context: LoggingContext) -> EventLoopFuture<StripeBankAccount> {
-        return verify(id: id, customer: customer, amounts: amounts, expand: expand)
+        return verify(id: id, customer: customer, amounts: amounts, expand: expand, context: context)
     }
     
     public func delete(id: String, customer: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
-        return delete(id: id, customer: customer)
+        return delete(id: id, customer: customer, context: context)
     }
     
     public func listAll(customer: String, filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeBankAccountList> {
-        return listAll(customer: customer, filter: filter)
+        return listAll(customer: customer, filter: filter, context: context)
     }
 }
 
@@ -155,7 +156,7 @@ public struct StripeBankAccountRoutes: BankAccountRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(bankaccounts)/\(customer)/sources", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(bankaccounts)/\(customer)/sources", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(id: String, customer: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeBankAccount> {
@@ -163,7 +164,7 @@ public struct StripeBankAccountRoutes: BankAccountRoutes {
         if let expand = expand {
             queryParams = ["expand": expand].queryParameters
         }
-        return apiHandler.send(method: .GET, path: "\(bankaccounts)/\(customer)/sources/\(id)", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(bankaccounts)/\(customer)/sources/\(id)", query: queryParams, headers: headers, context: context)
     }
     
     public func update(id: String,
@@ -191,7 +192,7 @@ public struct StripeBankAccountRoutes: BankAccountRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(bankaccounts)/\(customer)/sources/\(id)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(bankaccounts)/\(customer)/sources/\(id)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func verify(id: String, customer: String, amounts: [Int]?, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeBankAccount> {
@@ -205,19 +206,19 @@ public struct StripeBankAccountRoutes: BankAccountRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(bankaccounts)/\(customer)/sources/\(id)/verify", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(bankaccounts)/\(customer)/sources/\(id)/verify", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func delete(id: String, customer: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
-        return apiHandler.send(method: .DELETE, path: "\(bankaccounts)/\(customer)/sources/\(id)", headers: headers)
+        return apiHandler.send(method: .DELETE, path: "\(bankaccounts)/\(customer)/sources/\(id)", headers: headers, context: context)
     }
     
-    public func listAll(customer: String, filter: [String: Any]?, context: LoggingContextz) -> EventLoopFuture<StripeBankAccountList> {
+    public func listAll(customer: String, filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeBankAccountList> {
         var queryParams = "object=bank_account"
         if let filter = filter {
             queryParams += "&" + filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: "\(bankaccounts)/\(customer)/sources", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(bankaccounts)/\(customer)/sources", query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Payment Methods/Cards/CardRoutes.swift
+++ b/Sources/StripeKit/Payment Methods/Cards/CardRoutes.swift
@@ -87,11 +87,11 @@ extension CardRoutes {
                        metadata: [String: String]? = nil,
                        expand: [String]? = nil,
                        context: LoggingContext) -> EventLoopFuture<StripeCard> {
-        return create(customer: customer, source: source, metadata: metadata, expand: expand)
+        return create(customer: customer, source: source, metadata: metadata, expand: expand, context: context)
     }
     
     public func retrieve(id: String, customer: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeCard> {
-        return retrieve(id: id, customer: customer, expand: expand)
+        return retrieve(id: id, customer: customer, expand: expand, context: context)
     }
     
     public func update(id: String,
@@ -120,15 +120,16 @@ extension CardRoutes {
                       expYear: expYear,
                       metadata: metadata,
                       name: name,
-                      expand: expand)
+                      expand: expand,
+                      context: context)
     }
     
     public func delete(id: String, customer: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
-        return delete(id: id, customer: customer)
+        return delete(id: id, customer: customer, context: context)
     }
     
     public func listAll(customer: String, filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeCardList> {
-        return listAll(customer: customer, filter: filter)
+        return listAll(customer: customer, filter: filter, context: context)
     }
 }
 
@@ -161,7 +162,7 @@ public struct StripeCardRoutes: CardRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(cards)/\(customer)/sources", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(cards)/\(customer)/sources", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(id: String, customer: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripeCard> {
@@ -170,7 +171,7 @@ public struct StripeCardRoutes: CardRoutes {
             queryParams = ["expand": expand].queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: "\(cards)/\(customer)/sources/\(id)", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(cards)/\(customer)/sources/\(id)", query: queryParams, headers: headers, context: context)
     }
     
     public func update(id: String,
@@ -233,11 +234,11 @@ public struct StripeCardRoutes: CardRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(cards)/\(customer)/sources/\(id)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(cards)/\(customer)/sources/\(id)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func delete(id: String, customer: String, context: LoggingContext) -> EventLoopFuture<StripeDeletedObject> {
-        return apiHandler.send(method: .DELETE, path: "\(cards)/\(customer)/sources/\(id)", headers: headers)
+        return apiHandler.send(method: .DELETE, path: "\(cards)/\(customer)/sources/\(id)", headers: headers, context: context)
     }
     
     public func listAll(customer: String, filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeCardList> {
@@ -246,6 +247,6 @@ public struct StripeCardRoutes: CardRoutes {
             queryParams += "&" + filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: "\(cards)/\(customer)/sources", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(cards)/\(customer)/sources", query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Payment Methods/PaymentMethods/PaymentMethodRoutes.swift
+++ b/Sources/StripeKit/Payment Methods/PaymentMethods/PaymentMethodRoutes.swift
@@ -150,11 +150,12 @@ extension PaymentMethodRoutes {
                       metadata: metadata,
                       sepaDebit: sepaDebit,
                       sofort: sofort,
-                      expand: expand)
+                      expand: expand,
+                      context: context)
     }
     
     public func retrieve(paymentMethod: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripePaymentMethod> {
-        return retrieve(paymentMethod: paymentMethod, expand: expand)
+        return retrieve(paymentMethod: paymentMethod, expand: expand, context: context)
     }
     
     public func update(paymentMethod: String,
@@ -167,7 +168,8 @@ extension PaymentMethodRoutes {
                       billingDetails: billingDetails,
                       card: card,
                       metadata: metadata,
-                      expand: expand)
+                      expand: expand,
+                      context: context)
     }
     
     public func listAll(customer: String,
@@ -175,16 +177,17 @@ extension PaymentMethodRoutes {
                         filter: [String: Any]? = nil,
                         context: LoggingContext) -> EventLoopFuture<StripePaymentMethodList> {
         return listAll(customer: customer,
-                           type: type,
-                           filter: filter)
+                       type: type,
+                       filter: filter,
+                       context: context)
     }
     
     public func attach(paymentMethod: String, customer: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripePaymentMethod> {
-        return attach(paymentMethod: paymentMethod, customer: customer, expand: expand)
+        return attach(paymentMethod: paymentMethod, customer: customer, expand: expand, context: context)
     }
     
     public func detach(paymentMethod: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripePaymentMethod> {
-        return detach(paymentMethod: paymentMethod, expand: expand)
+        return detach(paymentMethod: paymentMethod, expand: expand, context: context)
     }
 }
 
@@ -292,7 +295,7 @@ public struct StripePaymentMethodRoutes: PaymentMethodRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: paymentmethods, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: paymentmethods, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(paymentMethod: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripePaymentMethod> {
@@ -301,7 +304,7 @@ public struct StripePaymentMethodRoutes: PaymentMethodRoutes {
             queryParams = ["expand": expand].queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: "\(paymentmethods)/\(paymentMethod)", query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(paymentmethods)/\(paymentMethod)", query: queryParams, headers: headers, context: context)
     }
     
     public func update(paymentMethod: String,
@@ -328,7 +331,7 @@ public struct StripePaymentMethodRoutes: PaymentMethodRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(paymentmethods)/\(paymentMethod)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(paymentmethods)/\(paymentMethod)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func listAll(customer: String, type: StripePaymentMethodType, filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripePaymentMethodList> {
@@ -337,7 +340,7 @@ public struct StripePaymentMethodRoutes: PaymentMethodRoutes {
             queryParams += "&" + filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: paymentmethods, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: paymentmethods, query: queryParams, headers: headers, context: context)
     }
     
     public func attach(paymentMethod: String, customer: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripePaymentMethod> {
@@ -347,7 +350,7 @@ public struct StripePaymentMethodRoutes: PaymentMethodRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(paymentmethods)/\(paymentMethod)/attach", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(paymentmethods)/\(paymentMethod)/attach", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func detach(paymentMethod: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripePaymentMethod> {
@@ -357,6 +360,6 @@ public struct StripePaymentMethodRoutes: PaymentMethodRoutes {
             body["expand"] = expand
         }
         
-        return apiHandler.send(method: .POST, path: "\(paymentmethods)/\(paymentMethod)/detach", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(paymentmethods)/\(paymentMethod)/detach", body: .string(body.queryParameters), headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Payment Methods/PaymentMethods/PaymentMethodRoutes.swift
+++ b/Sources/StripeKit/Payment Methods/PaymentMethods/PaymentMethodRoutes.swift
@@ -7,6 +7,7 @@
 
 import NIO
 import NIOHTTP1
+import Baggage
 
 public protocol PaymentMethodRoutes {
     /// Creates a PaymentMethod object. Read the Stripe.js reference to learn how to create PaymentMethods via Stripe.js.
@@ -50,7 +51,8 @@ public protocol PaymentMethodRoutes {
                 metadata: [String: String]?,
                 sepaDebit: [String: Any]?,
                 sofort: [String: Any]?,
-                expand: [String]?) -> EventLoopFuture<StripePaymentMethod>
+                expand: [String]?,
+                context: LoggingContext) -> EventLoopFuture<StripePaymentMethod>
     
     /// Retrieves a PaymentMethod object.
     ///
@@ -58,7 +60,7 @@ public protocol PaymentMethodRoutes {
     ///   - paymentMethod: The ID of the PaymentMethod.
     ///   - expand: An array of properties to expand.
     /// - Returns: A `StripePaymentMethod`.
-    func retrieve(paymentMethod: String, expand: [String]?) -> EventLoopFuture<StripePaymentMethod>
+    func retrieve(paymentMethod: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripePaymentMethod>
     
     /// Updates a PaymentMethod object. A PaymentMethod must be attached a customer to be updated.
     ///
@@ -73,7 +75,8 @@ public protocol PaymentMethodRoutes {
                 billingDetails: [String: Any]?,
                 card: [String: Any]?,
                 metadata: [String: String]?,
-                expand: [String]?) -> EventLoopFuture<StripePaymentMethod>
+                expand: [String]?,
+                context: LoggingContext) -> EventLoopFuture<StripePaymentMethod>
     
     /// Returns a list of PaymentMethods for a given Customer
     ///
@@ -84,7 +87,8 @@ public protocol PaymentMethodRoutes {
     /// - Returns: A `StripePaymentMethodList`.
     func listAll(customer: String,
                  type: StripePaymentMethodType,
-                 filter: [String: Any]?) -> EventLoopFuture<StripePaymentMethodList>
+                 filter: [String: Any]?,
+                 context: LoggingContext) -> EventLoopFuture<StripePaymentMethodList>
     
     /// Attaches a PaymentMethod object to a Customer.
     ///
@@ -93,7 +97,7 @@ public protocol PaymentMethodRoutes {
     ///   - customer: The ID of the customer to which to attach the PaymentMethod.
     ///   - expand: An array of properties to expand.
     /// - Returns: A `StripePaymentMethod`.
-    func attach(paymentMethod: String, customer: String, expand: [String]?) -> EventLoopFuture<StripePaymentMethod>
+    func attach(paymentMethod: String, customer: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripePaymentMethod>
     
     /// Detaches a PaymentMethod object from a Customer.
     ///
@@ -101,7 +105,7 @@ public protocol PaymentMethodRoutes {
     ///   - paymentMethod: The PaymentMethod to detach from the customer.
     ///   - expand: An array of properties to expand.
     /// - Returns: A `StripePaymentMethod`.
-    func detach(paymentMethod: String, expand: [String]?) -> EventLoopFuture<StripePaymentMethod>
+    func detach(paymentMethod: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripePaymentMethod>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
@@ -126,7 +130,8 @@ extension PaymentMethodRoutes {
                        metadata: [String: String]? = nil,
                        sepaDebit: [String: Any]? = nil,
                        sofort: [String: Any]? = nil,
-                       expand: [String]? = nil) -> EventLoopFuture<StripePaymentMethod> {
+                       expand: [String]? = nil,
+                       context: LoggingContext) -> EventLoopFuture<StripePaymentMethod> {
         return create(type: type,
                       billingDetails: billingDetails,
                       afterpayClearpay: afterpayClearpay,
@@ -148,7 +153,7 @@ extension PaymentMethodRoutes {
                       expand: expand)
     }
     
-    public func retrieve(paymentMethod: String, expand: [String]? = nil) -> EventLoopFuture<StripePaymentMethod> {
+    public func retrieve(paymentMethod: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripePaymentMethod> {
         return retrieve(paymentMethod: paymentMethod, expand: expand)
     }
     
@@ -156,7 +161,8 @@ extension PaymentMethodRoutes {
                        billingDetails: [String: Any]? = nil,
                        card: [String: Any]? = nil,
                        metadata: [String: String]? = nil,
-                       expand: [String]? = nil) -> EventLoopFuture<StripePaymentMethod> {
+                       expand: [String]? = nil,
+                       context: LoggingContext) -> EventLoopFuture<StripePaymentMethod> {
         return update(paymentMethod: paymentMethod,
                       billingDetails: billingDetails,
                       card: card,
@@ -166,17 +172,18 @@ extension PaymentMethodRoutes {
     
     public func listAll(customer: String,
                         type: StripePaymentMethodType,
-                        filter: [String: Any]? = nil) -> EventLoopFuture<StripePaymentMethodList> {
+                        filter: [String: Any]? = nil,
+                        context: LoggingContext) -> EventLoopFuture<StripePaymentMethodList> {
         return listAll(customer: customer,
                            type: type,
                            filter: filter)
     }
     
-    public func attach(paymentMethod: String, customer: String, expand: [String]? = nil) -> EventLoopFuture<StripePaymentMethod> {
+    public func attach(paymentMethod: String, customer: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripePaymentMethod> {
         return attach(paymentMethod: paymentMethod, customer: customer, expand: expand)
     }
     
-    public func detach(paymentMethod: String, expand: [String]? = nil) -> EventLoopFuture<StripePaymentMethod> {
+    public func detach(paymentMethod: String, expand: [String]? = nil, context: LoggingContext) -> EventLoopFuture<StripePaymentMethod> {
         return detach(paymentMethod: paymentMethod, expand: expand)
     }
 }
@@ -209,7 +216,8 @@ public struct StripePaymentMethodRoutes: PaymentMethodRoutes {
                        metadata: [String: String]?,
                        sepaDebit: [String: Any]?,
                        sofort: [String: Any]?,
-                       expand: [String]?) -> EventLoopFuture<StripePaymentMethod> {
+                       expand: [String]?,
+                       context: LoggingContext) -> EventLoopFuture<StripePaymentMethod> {
         var body: [String: Any] = ["type": type.rawValue]
         
         if let billingDetails = billingDetails {
@@ -287,7 +295,7 @@ public struct StripePaymentMethodRoutes: PaymentMethodRoutes {
         return apiHandler.send(method: .POST, path: paymentmethods, body: .string(body.queryParameters), headers: headers)
     }
     
-    public func retrieve(paymentMethod: String, expand: [String]?) -> EventLoopFuture<StripePaymentMethod> {
+    public func retrieve(paymentMethod: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripePaymentMethod> {
         var queryParams = ""
         if let expand = expand {
             queryParams = ["expand": expand].queryParameters
@@ -300,7 +308,8 @@ public struct StripePaymentMethodRoutes: PaymentMethodRoutes {
                        billingDetails: [String: Any]?,
                        card: [String: Any]?,
                        metadata: [String: String]?,
-                       expand: [String]?) -> EventLoopFuture<StripePaymentMethod> {
+                       expand: [String]?,
+                       context: LoggingContext) -> EventLoopFuture<StripePaymentMethod> {
         var body: [String: Any] = [:]
         
         if let billingDetails = billingDetails {
@@ -322,7 +331,7 @@ public struct StripePaymentMethodRoutes: PaymentMethodRoutes {
         return apiHandler.send(method: .POST, path: "\(paymentmethods)/\(paymentMethod)", body: .string(body.queryParameters), headers: headers)
     }
     
-    public func listAll(customer: String, type: StripePaymentMethodType, filter: [String: Any]?) -> EventLoopFuture<StripePaymentMethodList> {
+    public func listAll(customer: String, type: StripePaymentMethodType, filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripePaymentMethodList> {
         var queryParams = "customer=\(customer)&type=\(type.rawValue)"
         if let filter = filter {
             queryParams += "&" + filter.queryParameters
@@ -331,7 +340,7 @@ public struct StripePaymentMethodRoutes: PaymentMethodRoutes {
         return apiHandler.send(method: .GET, path: paymentmethods, query: queryParams, headers: headers)
     }
     
-    public func attach(paymentMethod: String, customer: String, expand: [String]?) -> EventLoopFuture<StripePaymentMethod> {
+    public func attach(paymentMethod: String, customer: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripePaymentMethod> {
         var body: [String: Any] = ["customer": customer]
         
         if let expand = expand {
@@ -341,7 +350,7 @@ public struct StripePaymentMethodRoutes: PaymentMethodRoutes {
         return apiHandler.send(method: .POST, path: "\(paymentmethods)/\(paymentMethod)/attach", body: .string(body.queryParameters), headers: headers)
     }
     
-    public func detach(paymentMethod: String, expand: [String]?) -> EventLoopFuture<StripePaymentMethod> {
+    public func detach(paymentMethod: String, expand: [String]?, context: LoggingContext) -> EventLoopFuture<StripePaymentMethod> {
         var body: [String: Any] = [:]
         
         if let expand = expand {

--- a/Sources/StripeKit/Payment Methods/Sources/SourceRoutes.swift
+++ b/Sources/StripeKit/Payment Methods/Sources/SourceRoutes.swift
@@ -120,11 +120,12 @@ extension SourceRoutes {
                       statementDescriptor: statementDescriptor,
                       token: token,
                       usage: usage,
-                      sources: sources)
+                      sources: sources,
+                      context: context)
     }
     
     public func retrieve(source: String, clientSecret: String? = nil, context: LoggingContext) -> EventLoopFuture<StripeSource> {
-        return retrieve(source: source, clientSecret: clientSecret)
+        return retrieve(source: source, clientSecret: clientSecret, context: context)
     }
     
     public func update(source: String,
@@ -139,15 +140,16 @@ extension SourceRoutes {
                       mandate: mandate,
                       metadata: metadata,
                       owner: owner,
-                      sourceOrder: sourceOrder)
+                      sourceOrder: sourceOrder,
+                      context: context)
     }
     
     public func attach(source: String, customer: String, context: LoggingContext) -> EventLoopFuture<StripeSource> {
-        return attach(source: source, customer: customer)
+        return attach(source: source, customer: customer, context: context)
     }
     
     public func detach(id: String, customer: String, context: LoggingContext) -> EventLoopFuture<StripeSource> {
-        return detach(id: id, customer: customer)
+        return detach(id: id, customer: customer, context: context)
     }
 }
 
@@ -227,7 +229,7 @@ public struct StripeSourceRoutes: SourceRoutes {
             sources.forEach { body["\($0)"] = $1}
         }
         
-        return apiHandler.send(method: .POST, path: self.sources, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: self.sources, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(source: String, clientSecret: String?, context: LoggingContext) -> EventLoopFuture<StripeSource> {
@@ -235,7 +237,7 @@ public struct StripeSourceRoutes: SourceRoutes {
         if let clientSecret = clientSecret {
             query += "client_secret=\(clientSecret)"
         }
-        return apiHandler.send(method: .GET, path: "\(sources)/\(source)", query: query, headers: headers)
+        return apiHandler.send(method: .GET, path: "\(sources)/\(source)", query: query, headers: headers, context: context)
     }
     
     public func update(source: String,
@@ -267,15 +269,15 @@ public struct StripeSourceRoutes: SourceRoutes {
             sourceOrder.forEach { body["source_order[\($0)]"] = $1 }
         }
         
-        return apiHandler.send(method: .POST, path: "\(sources)/\(source)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(sources)/\(source)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func attach(source: String, customer: String, context: LoggingContext) -> EventLoopFuture<StripeSource> {
         let body: [String: Any] = ["source": source]
-        return apiHandler.send(method: .POST, path: "\(customers)/\(customer)/sources", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(customers)/\(customer)/sources", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func detach(id: String, customer: String, context: LoggingContext) -> EventLoopFuture<StripeSource> {
-        return apiHandler.send(method: .DELETE, path: "\(customers)/\(customer)/sources/\(id)", headers: headers)
+        return apiHandler.send(method: .DELETE, path: "\(customers)/\(customer)/sources/\(id)", headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Reporting/ReportRuns/ReportRunRoutes.swift
+++ b/Sources/StripeKit/Reporting/ReportRuns/ReportRunRoutes.swift
@@ -30,15 +30,15 @@ public protocol ReportRunRoutes {
 
 extension ReportRunRoutes {
     public func create(reportType: String, parameters: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeReportRun> {
-        return create(reportType: reportType, parameters: parameters)
+        return create(reportType: reportType, parameters: parameters, context: context)
     }
     
     public func retrieve(reportRun: String, context: LoggingContext) -> EventLoopFuture<StripeReportRun> {
-        return retrieve(reportRun: reportRun)
+        return retrieve(reportRun: reportRun, context: context)
     }
     
     public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeReportRunList> {
-        return listAll(filter: filter)
+        return listAll(filter: filter, context: context)
     }
 }
 
@@ -59,11 +59,11 @@ public struct StripeReportRunRoutes: ReportRunRoutes {
             parameters.forEach { body["parameters[\($0)]"] = $1 }
         }
         
-        return apiHandler.send(method: .POST, path: reportruns, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: reportruns, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(reportRun: String, context: LoggingContext) -> EventLoopFuture<StripeReportRun> {
-        return apiHandler.send(method: .GET, path: "\(reportruns)/\(reportRun)", headers: headers)
+        return apiHandler.send(method: .GET, path: "\(reportruns)/\(reportRun)", headers: headers, context: context)
     }
     
     public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeReportRunList> {
@@ -71,6 +71,6 @@ public struct StripeReportRunRoutes: ReportRunRoutes {
         if let filter = filter {
             queryParams = filter.queryParameters
         }
-        return apiHandler.send(method: .GET, path: reportruns, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: reportruns, query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Reporting/ReportRuns/ReportRunRoutes.swift
+++ b/Sources/StripeKit/Reporting/ReportRuns/ReportRunRoutes.swift
@@ -7,36 +7,37 @@
 
 import NIO
 import NIOHTTP1
+import Baggage
 
 public protocol ReportRunRoutes {
     
     /// Creates a new object and begin running the report. (Requires a live-mode API key.)
     /// - Parameter reportType: The ID of the report type to run, such as "balance.summary.1".
     /// - Parameter parameters: Parameters specifying how the report should be run. Different Report Types have different required and optional parameters, listed in the [API Access to Reports](https://stripe.com/docs/reporting/statements/api) documentation.
-    func create(reportType: String, parameters: [String: Any]?) -> EventLoopFuture<StripeReportRun>
+    func create(reportType: String, parameters: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeReportRun>
     
     /// Retrieves the details of an existing Report Run. (Requires a live-mode API key.)
     /// - Parameter reportRun: The ID of the run to retrieve
-    func retrieve(reportRun: String) -> EventLoopFuture<StripeReportRun>
+    func retrieve(reportRun: String, context: LoggingContext) -> EventLoopFuture<StripeReportRun>
     
     /// Returns a list of Report Runs, with the most recent appearing first. (Requires a live-mode API key.)
     /// - Parameter filter: A dictionary that will be used for the query parameters. [See More →](https://stripe.com/docs/api/reporting/report_run/list)
-    func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeReportRunList>
+    func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeReportRunList>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
 }
 
 extension ReportRunRoutes {
-    public func create(reportType: String, parameters: [String: Any]? = nil) -> EventLoopFuture<StripeReportRun> {
+    public func create(reportType: String, parameters: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeReportRun> {
         return create(reportType: reportType, parameters: parameters)
     }
     
-    public func retrieve(reportRun: String) -> EventLoopFuture<StripeReportRun> {
+    public func retrieve(reportRun: String, context: LoggingContext) -> EventLoopFuture<StripeReportRun> {
         return retrieve(reportRun: reportRun)
     }
     
-    public func listAll(filter: [String: Any]? = nil) -> EventLoopFuture<StripeReportRunList> {
+    public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeReportRunList> {
         return listAll(filter: filter)
     }
 }
@@ -51,7 +52,7 @@ public struct StripeReportRunRoutes: ReportRunRoutes {
         self.apiHandler = apiHandler
     }
 
-    public func create(reportType: String, parameters: [String: Any]? = nil) -> EventLoopFuture<StripeReportRun> {
+    public func create(reportType: String, parameters: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeReportRun> {
         var body: [String: Any] = ["report_type": reportType]
         
         if let parameters = parameters {
@@ -61,11 +62,11 @@ public struct StripeReportRunRoutes: ReportRunRoutes {
         return apiHandler.send(method: .POST, path: reportruns, body: .string(body.queryParameters), headers: headers)
     }
     
-    public func retrieve(reportRun: String) -> EventLoopFuture<StripeReportRun> {
+    public func retrieve(reportRun: String, context: LoggingContext) -> EventLoopFuture<StripeReportRun> {
         return apiHandler.send(method: .GET, path: "\(reportruns)/\(reportRun)", headers: headers)
     }
     
-    public func listAll(filter: [String: Any]? = nil) -> EventLoopFuture<StripeReportRunList> {
+    public func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeReportRunList> {
         var queryParams = ""
         if let filter = filter {
             queryParams = filter.queryParameters

--- a/Sources/StripeKit/Reporting/ReportTypes/ReportTypeRoutes.swift
+++ b/Sources/StripeKit/Reporting/ReportTypes/ReportTypeRoutes.swift
@@ -33,10 +33,10 @@ public struct StripeReportTypeRoutes: ReportTypeRoutes {
     }
     
     public func retrieve(reportType: String, context: LoggingContext) -> EventLoopFuture<StripeReportType> {
-        return apiHandler.send(method: .GET, path: "\(reporttypes)/\(reportType)", headers: headers)
+        return apiHandler.send(method: .GET, path: "\(reporttypes)/\(reportType)", headers: headers, context: context)
     }
     
     public func listAll(context: LoggingContext) -> EventLoopFuture<StripeReportTypeList> {
-        return apiHandler.send(method: .GET, path: reporttypes, headers: headers)
+        return apiHandler.send(method: .GET, path: reporttypes, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Reporting/ReportTypes/ReportTypeRoutes.swift
+++ b/Sources/StripeKit/Reporting/ReportTypes/ReportTypeRoutes.swift
@@ -7,15 +7,16 @@
 
 import NIO
 import NIOHTTP1
+import Baggage
 
 public protocol ReportTypeRoutes {
     
     /// Retrieves the details of a Report Type. (Requires a live-mode API key.)
     /// - Parameter reportType: The ID of the Report Type to retrieve, such as `balance.summary.1`.
-    func retrieve(reportType: String) -> EventLoopFuture<StripeReportType>
+    func retrieve(reportType: String, context: LoggingContext) -> EventLoopFuture<StripeReportType>
     
     /// Returns a full list of Report Types. (Requires a live-mode API key.)
-    func listAll() -> EventLoopFuture<StripeReportTypeList>
+    func listAll(context: LoggingContext) -> EventLoopFuture<StripeReportTypeList>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
@@ -31,11 +32,11 @@ public struct StripeReportTypeRoutes: ReportTypeRoutes {
         self.apiHandler = apiHandler
     }
     
-    public func retrieve(reportType: String) -> EventLoopFuture<StripeReportType> {
+    public func retrieve(reportType: String, context: LoggingContext) -> EventLoopFuture<StripeReportType> {
         return apiHandler.send(method: .GET, path: "\(reporttypes)/\(reportType)", headers: headers)
     }
     
-    public func listAll() -> EventLoopFuture<StripeReportTypeList> {
+    public func listAll(context: LoggingContext) -> EventLoopFuture<StripeReportTypeList> {
         return apiHandler.send(method: .GET, path: reporttypes, headers: headers)
     }
 }

--- a/Sources/StripeKit/Sigma/Scheduled Queries/ScheduledQueryRunRoutes.swift
+++ b/Sources/StripeKit/Sigma/Scheduled Queries/ScheduledQueryRunRoutes.swift
@@ -28,11 +28,11 @@ public protocol ScheduledQueryRunRoutes {
 
 extension ScheduledQueryRunRoutes {
     func retrieve(scheduledQueryRun: String, context: LoggingContext) -> EventLoopFuture<StripeScheduledQueryRun> {
-        return retrieve(scheduledQueryRun: scheduledQueryRun)
+        return retrieve(scheduledQueryRun: scheduledQueryRun, context: context)
     }
     
     func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeScheduledQueryRunList> {
-        return listAll(filter: filter)
+        return listAll(filter: filter, context: context)
     }
 }
 
@@ -47,7 +47,7 @@ public struct StripeScheduledQueryRunRoutes: ScheduledQueryRunRoutes {
     }
     
     public func retrieve(scheduledQueryRun: String, context: LoggingContext) -> EventLoopFuture<StripeScheduledQueryRun> {
-        return apiHandler.send(method: .GET, path: "\(scheduledqueryruns)/\(scheduledQueryRun)", headers: headers)
+        return apiHandler.send(method: .GET, path: "\(scheduledqueryruns)/\(scheduledQueryRun)", headers: headers, context: context)
     }
     
     public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeScheduledQueryRunList> {
@@ -56,6 +56,6 @@ public struct StripeScheduledQueryRunRoutes: ScheduledQueryRunRoutes {
             queryParams = filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: scheduledqueryruns, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: scheduledqueryruns, query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Sigma/Scheduled Queries/ScheduledQueryRunRoutes.swift
+++ b/Sources/StripeKit/Sigma/Scheduled Queries/ScheduledQueryRunRoutes.swift
@@ -7,30 +7,31 @@
 
 import NIO
 import NIOHTTP1
+import Baggage
 
 public protocol ScheduledQueryRunRoutes {
     /// Retrieves the details of an scheduled query run.
     ///
     /// - Parameter scheduledQueryRun: Unique identifier for the object.
     /// - Returns: A `StripeScheduledQueryRun`.
-    func retrieve(scheduledQueryRun: String) -> EventLoopFuture<StripeScheduledQueryRun>
+    func retrieve(scheduledQueryRun: String, context: LoggingContext) -> EventLoopFuture<StripeScheduledQueryRun>
     
     /// Returns a list of scheduled query runs.
     ///
     /// - Parameter filter: A dictionary that will be used for the query parameters. [See More →](https://stripe.com/docs/api/sigma/scheduled_queries/list)
     /// - Returns: A `StripeScheduledQueryRunList`.
-    func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeScheduledQueryRunList>
+    func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeScheduledQueryRunList>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
 }
 
 extension ScheduledQueryRunRoutes {
-    func retrieve(scheduledQueryRun: String) -> EventLoopFuture<StripeScheduledQueryRun> {
+    func retrieve(scheduledQueryRun: String, context: LoggingContext) -> EventLoopFuture<StripeScheduledQueryRun> {
         return retrieve(scheduledQueryRun: scheduledQueryRun)
     }
     
-    func listAll(filter: [String: Any]? = nil) -> EventLoopFuture<StripeScheduledQueryRunList> {
+    func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeScheduledQueryRunList> {
         return listAll(filter: filter)
     }
 }
@@ -45,11 +46,11 @@ public struct StripeScheduledQueryRunRoutes: ScheduledQueryRunRoutes {
         self.apiHandler = apiHandler
     }
     
-    public func retrieve(scheduledQueryRun: String) -> EventLoopFuture<StripeScheduledQueryRun> {
+    public func retrieve(scheduledQueryRun: String, context: LoggingContext) -> EventLoopFuture<StripeScheduledQueryRun> {
         return apiHandler.send(method: .GET, path: "\(scheduledqueryruns)/\(scheduledQueryRun)", headers: headers)
     }
     
-    public func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeScheduledQueryRunList> {
+    public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeScheduledQueryRunList> {
         var queryParams = ""
         if let filter = filter {
             queryParams = filter.queryParameters

--- a/Sources/StripeKit/StripeClient.swift
+++ b/Sources/StripeKit/StripeClient.swift
@@ -199,4 +199,13 @@ public final class StripeClient {
         handler.eventLoop = eventLoop
         return self
     }
+
+    /// Hop to a new eventloop to execute requests on with a different API key.
+    /// - Parameter eventLoop: The eventloop to execute requests on.
+    /// - Parameter apiKey: The new API key to use.
+    public func hopped(to eventLoop: EventLoop, apiKey: String) -> StripeClient {
+        handler.eventLoop = eventLoop
+        handler.apiKey = apiKey
+        return self
+    }
 }

--- a/Sources/StripeKit/StripeRequest.swift
+++ b/Sources/StripeKit/StripeRequest.swift
@@ -42,7 +42,7 @@ extension StripeAPIHandler {
     }
 }
 
-struct StripeDefaultAPIHandler: StripeAPIHandler {
+final class StripeDefaultAPIHandler: StripeAPIHandler {
     private let httpClient: HTTPClient
     var apiKey: String
     private let decoder = JSONDecoder()

--- a/Sources/StripeKit/StripeRequest.swift
+++ b/Sources/StripeKit/StripeRequest.swift
@@ -22,7 +22,8 @@ public protocol StripeAPIHandler {
                                path: String,
                                query: String,
                                body: HTTPClient.Body,
-                               headers: HTTPHeaders) -> EventLoopFuture<SM>
+                               headers: HTTPHeaders,
+                               context: LoggingContext) -> EventLoopFuture<SM>
 }
 
 extension StripeAPIHandler {
@@ -30,12 +31,14 @@ extension StripeAPIHandler {
                                path: String,
                                query: String = "",
                                body: HTTPClient.Body = .string(""),
-                               headers: HTTPHeaders = [:]) -> EventLoopFuture<SM> {
+                               headers: HTTPHeaders = [:],
+                               context: LoggingContext) -> EventLoopFuture<SM> {
         return send(method: method,
                     path: path,
                     query: query,
                     body: body,
-                    headers: headers)
+                    headers: headers,
+                    context: context)
     }
 }
 

--- a/Sources/StripeKit/Terminal/ConnectionToken/ConnectionTokenRoutes.swift
+++ b/Sources/StripeKit/Terminal/ConnectionToken/ConnectionTokenRoutes.swift
@@ -7,6 +7,7 @@
 
 import NIO
 import NIOHTTP1
+import Baggage
 
 public protocol ConnectionTokenRoutes {
     /// To connect to a reader the Stripe Terminal SDK needs to retrieve a short-lived connection token from Stripe, proxied through your server. On your backend, add an endpoint that creates and returns a connection token.

--- a/Sources/StripeKit/Terminal/ConnectionToken/ConnectionTokenRoutes.swift
+++ b/Sources/StripeKit/Terminal/ConnectionToken/ConnectionTokenRoutes.swift
@@ -14,15 +14,15 @@ public protocol ConnectionTokenRoutes {
     ///
     /// - Parameter location: The id of the location that this connection token is scoped to. If specified the connection token will only be usable with readers assigned to that location, otherwise the connection token will be usable with all readers.
     /// - Returns: A `StripeConnectionToken`.
-    func create(location: String?) -> EventLoopFuture<StripeConnectionToken>
+    func create(location: String?, context: LoggingContext) -> EventLoopFuture<StripeConnectionToken>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
 }
 
 extension ConnectionTokenRoutes {
-    func create(location: String? = nil) -> EventLoopFuture<StripeConnectionToken> {
-        return create(location: location)
+    func create(location: String? = nil, context: LoggingContext) -> EventLoopFuture<StripeConnectionToken> {
+        return create(location: location, context: context)
     }
 }
 
@@ -36,7 +36,7 @@ public struct StripeConnectionTokenRoutes: ConnectionTokenRoutes {
         self.apiHandler = apiHandler
     }
     
-    public func create(location: String?) -> EventLoopFuture<StripeConnectionToken> {
-        return apiHandler.send(method: .POST, path: connectiontokens, headers: headers)
+    public func create(location: String?, context: LoggingContext) -> EventLoopFuture<StripeConnectionToken> {
+        return apiHandler.send(method: .POST, path: connectiontokens, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Terminal/Locations/LocationRoutes.swift
+++ b/Sources/StripeKit/Terminal/Locations/LocationRoutes.swift
@@ -53,23 +53,23 @@ public protocol LocationRoutes {
 
 extension LocationRoutes {
     func create(address: [String: Any], displayName: String, metadata: [String: String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeLocation> {
-        return create(address: address, displayName: displayName, metadata: metadata)
+        return create(address: address, displayName: displayName, metadata: metadata, context: context)
     }
     
     func retrieve(location: String, context: LoggingContext) -> EventLoopFuture<StripeLocation> {
-        return retrieve(location: location)
+        return retrieve(location: location, context: context)
     }
     
     func update(location: String, address: [String: Any]? = nil, displayName: String? = nil, metadata: [String: String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeLocation> {
-        return update(location: location, address: address, displayName: displayName, metadata: metadata)
+        return update(location: location, address: address, displayName: displayName, metadata: metadata, context: context)
     }
     
     func delete(location: String, context: LoggingContext) -> EventLoopFuture<StripeLocation> {
-        return delete(location: location)
+        return delete(location: location, context: context)
     }
     
     func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeLocationList> {
-        return listAll(filter: filter)
+        return listAll(filter: filter, context: context)
     }
 }
 
@@ -91,11 +91,11 @@ public struct StripeLocationRoutes: LocationRoutes {
             metadata.forEach { body["metadata[\($0)]"] = $1 }
         }
         
-        return apiHandler.send(method: .POST, path: terminallocations, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: terminallocations, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(location: String, context: LoggingContext) -> EventLoopFuture<StripeLocation> {
-        return apiHandler.send(method: .GET, path: "\(terminallocations)/\(location)", headers: headers)
+        return apiHandler.send(method: .GET, path: "\(terminallocations)/\(location)", headers: headers, context: context)
     }
     
     public func update(location: String, address: [String: Any]?, displayName: String?, metadata: [String: String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeLocation> {
@@ -112,11 +112,11 @@ public struct StripeLocationRoutes: LocationRoutes {
             metadata.forEach { body["metadata[\($0)]"] = $1 }
         }
         
-        return apiHandler.send(method: .POST, path: "\(terminallocations)/\(location)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(terminallocations)/\(location)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func delete(location: String, context: LoggingContext) -> EventLoopFuture<StripeLocation> {
-        return apiHandler.send(method: .DELETE, path: "\(terminallocations)/\(location)", headers: headers)
+        return apiHandler.send(method: .DELETE, path: "\(terminallocations)/\(location)", headers: headers, context: context)
     }
     
     public func listAll(filter: [String : Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeLocationList> {
@@ -125,6 +125,6 @@ public struct StripeLocationRoutes: LocationRoutes {
             queryParams = filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: terminallocations, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: terminallocations, query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Terminal/Locations/LocationRoutes.swift
+++ b/Sources/StripeKit/Terminal/Locations/LocationRoutes.swift
@@ -7,6 +7,7 @@
 
 import NIO
 import NIOHTTP1
+import Baggage
 
 public protocol LocationRoutes {
     /// Creates a new Location object.
@@ -16,13 +17,13 @@ public protocol LocationRoutes {
     ///   - displayName: A name for the location.
     ///   - metadata: Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
     /// - Returns: A `StripeLocation`.
-    func create(address: [String: Any], displayName: String, metadata: [String: String]?) -> EventLoopFuture<StripeLocation>
+    func create(address: [String: Any], displayName: String, metadata: [String: String]?, context: LoggingContext) -> EventLoopFuture<StripeLocation>
     
     /// Retrieves a Location object.
     ///
     /// - Parameter location: The identifier of the location to be retrieved.
     /// - Returns: A `StripeLocation`.
-    func retrieve(location: String) -> EventLoopFuture<StripeLocation>
+    func retrieve(location: String, context: LoggingContext) -> EventLoopFuture<StripeLocation>
     
     /// Updates a Location object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
     ///
@@ -32,42 +33,42 @@ public protocol LocationRoutes {
     ///   - displayName: A name for the location.
     ///   - metadata: Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
     /// - Returns: A `StripeLocation`.
-    func update(location: String, address: [String: Any]?, displayName: String?, metadata: [String: String]?) -> EventLoopFuture<StripeLocation>
+    func update(location: String, address: [String: Any]?, displayName: String?, metadata: [String: String]?, context: LoggingContext) -> EventLoopFuture<StripeLocation>
     
     /// Deletes a Location object.
     ///
     /// - Parameter location: The identifier of the location to be deleted.
     /// - Returns: A `StripeLocation`.
-    func delete(location: String) -> EventLoopFuture<StripeLocation>
+    func delete(location: String, context: LoggingContext) -> EventLoopFuture<StripeLocation>
     
     /// Returns a list of Location objects.
     ///
     /// - Parameter filter: A dictionary that will be used for the query parameters. [See More →](https://stripe.com/docs/api/terminal/locations/list)
     /// - Returns: A `StripeLocationList`.
-    func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeLocationList>
+    func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeLocationList>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
 }
 
 extension LocationRoutes {
-    func create(address: [String: Any], displayName: String, metadata: [String: String]? = nil) -> EventLoopFuture<StripeLocation> {
+    func create(address: [String: Any], displayName: String, metadata: [String: String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeLocation> {
         return create(address: address, displayName: displayName, metadata: metadata)
     }
     
-    func retrieve(location: String) -> EventLoopFuture<StripeLocation> {
+    func retrieve(location: String, context: LoggingContext) -> EventLoopFuture<StripeLocation> {
         return retrieve(location: location)
     }
     
-    func update(location: String, address: [String: Any]? = nil, displayName: String? = nil, metadata: [String: String]? = nil) -> EventLoopFuture<StripeLocation> {
+    func update(location: String, address: [String: Any]? = nil, displayName: String? = nil, metadata: [String: String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeLocation> {
         return update(location: location, address: address, displayName: displayName, metadata: metadata)
     }
     
-    func delete(location: String) -> EventLoopFuture<StripeLocation> {
+    func delete(location: String, context: LoggingContext) -> EventLoopFuture<StripeLocation> {
         return delete(location: location)
     }
     
-    func listAll(filter: [String: Any]? = nil) -> EventLoopFuture<StripeLocationList> {
+    func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeLocationList> {
         return listAll(filter: filter)
     }
 }
@@ -82,7 +83,7 @@ public struct StripeLocationRoutes: LocationRoutes {
         self.apiHandler = apiHandler
     }
     
-    public func create(address: [String: Any], displayName: String, metadata: [String: String]? = nil) -> EventLoopFuture<StripeLocation> {
+    public func create(address: [String: Any], displayName: String, metadata: [String: String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeLocation> {
         var body: [String: Any] = ["display_name": displayName]
         address.forEach { body["address[\($0)]"] = $1 }
         
@@ -93,11 +94,11 @@ public struct StripeLocationRoutes: LocationRoutes {
         return apiHandler.send(method: .POST, path: terminallocations, body: .string(body.queryParameters), headers: headers)
     }
     
-    public func retrieve(location: String) -> EventLoopFuture<StripeLocation> {
+    public func retrieve(location: String, context: LoggingContext) -> EventLoopFuture<StripeLocation> {
         return apiHandler.send(method: .GET, path: "\(terminallocations)/\(location)", headers: headers)
     }
     
-    public func update(location: String, address: [String: Any]?, displayName: String?, metadata: [String: String]? = nil) -> EventLoopFuture<StripeLocation> {
+    public func update(location: String, address: [String: Any]?, displayName: String?, metadata: [String: String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeLocation> {
         var body: [String: Any] = [:]
         if let address = address {
             address.forEach { body["address[\($0)]"] = $1 }
@@ -114,11 +115,11 @@ public struct StripeLocationRoutes: LocationRoutes {
         return apiHandler.send(method: .POST, path: "\(terminallocations)/\(location)", body: .string(body.queryParameters), headers: headers)
     }
     
-    public func delete(location: String) -> EventLoopFuture<StripeLocation> {
+    public func delete(location: String, context: LoggingContext) -> EventLoopFuture<StripeLocation> {
         return apiHandler.send(method: .DELETE, path: "\(terminallocations)/\(location)", headers: headers)
     }
     
-    public func listAll(filter: [String : Any]? = nil) -> EventLoopFuture<StripeLocationList> {
+    public func listAll(filter: [String : Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeLocationList> {
         var queryParams = ""
         if let filter = filter {
             queryParams = filter.queryParameters

--- a/Sources/StripeKit/Terminal/Reader/ReaderRoutes.swift
+++ b/Sources/StripeKit/Terminal/Reader/ReaderRoutes.swift
@@ -7,6 +7,7 @@
 
 import NIO
 import NIOHTTP1
+import Baggage
 
 public protocol ReaderRoutes {
     /// Creates a new Reader object.
@@ -17,13 +18,13 @@ public protocol ReaderRoutes {
     ///   - location: The location to assign the reader to. If no location is specified, the reader will be assigned to the account’s default location.
     ///   - metadata: Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
     /// - Returns: A `StripeReader`.
-    func create(registrationCode: String, label: String?, location: String?, metadata: [String: String]?) -> EventLoopFuture<StripeReader>
+    func create(registrationCode: String, label: String?, location: String?, metadata: [String: String]?, context: LoggingContext) -> EventLoopFuture<StripeReader>
     
     /// Retrieves a Reader object.
     ///
     /// - Parameter reader: The identifier of the reader to be retrieved.
     /// - Returns: A `StripeReader`.
-    func retrieve(reader: String) -> EventLoopFuture<StripeReader>
+    func retrieve(reader: String, context: LoggingContext) -> EventLoopFuture<StripeReader>
     
     /// Updates a Reader object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
     ///
@@ -32,42 +33,42 @@ public protocol ReaderRoutes {
     ///   - label: The new label of the reader.
     ///   - metadata: Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
     /// - Returns: A `StripeReader`.
-    func update(reader: String, label: String?, metadata: [String: String]?) -> EventLoopFuture<StripeReader>
+    func update(reader: String, label: String?, metadata: [String: String]?, context: LoggingContext) -> EventLoopFuture<StripeReader>
     
     /// Deletes a Reader object.
     ///
     /// - Parameter reader: The identifier of the reader to be deleted.
     /// - Returns: A `StripeReader`.
-    func delete(reader: String) -> EventLoopFuture<StripeReader>
+    func delete(reader: String, context: LoggingContext) -> EventLoopFuture<StripeReader>
     
     /// Returns a list of Reader objects.
     ///
     /// - Parameter filter: A dictionary that will be used for the query parameters. [See More →](https://stripe.com/docs/api/terminal/readers/list)
     /// - Returns: A `StripeReaderList`.
-    func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeReaderList>
+    func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeReaderList>
     
     /// Headers to send with the request.
     var headers: HTTPHeaders { get set }
 }
 
 extension ReaderRoutes {
-    func create(registrationCode: String, label: String? = nil, location: String? = nil, metadata: [String: String]? = nil) -> EventLoopFuture<StripeReader> {
+    func create(registrationCode: String, label: String? = nil, location: String? = nil, metadata: [String: String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeReader> {
         return create(registrationCode: registrationCode, label: label, location: location, metadata: metadata)
     }
     
-    func retrieve(reader: String) -> EventLoopFuture<StripeReader> {
+    func retrieve(reader: String, context: LoggingContext) -> EventLoopFuture<StripeReader> {
         return retrieve(reader: reader)
     }
     
-    func update(reader: String, label: String? = nil, metadata: [String: String]? = nil) -> EventLoopFuture<StripeReader> {
+    func update(reader: String, label: String? = nil, metadata: [String: String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeReader> {
         return update(reader: reader, label: label, metadata: metadata)
     }
     
-    func delete(reader: String) -> EventLoopFuture<StripeReader> {
+    func delete(reader: String, context: LoggingContext) -> EventLoopFuture<StripeReader> {
         return delete(reader: reader)
     }
     
-    func listAll(filter: [String: Any]? = nil) -> EventLoopFuture<StripeReaderList> {
+    func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeReaderList> {
         return listAll(filter: filter)
     }
 }
@@ -82,7 +83,7 @@ public struct StripeReaderRoutes: ReaderRoutes {
         self.apiHandler = apiHandler
     }
     
-    public func create(registrationCode: String, label: String?, location: String?, metadata: [String: String]?) -> EventLoopFuture<StripeReader> {
+    public func create(registrationCode: String, label: String?, location: String?, metadata: [String: String]?, context: LoggingContext) -> EventLoopFuture<StripeReader> {
         var body: [String: Any] = ["registration_code": registrationCode]
         
         if let label = label {
@@ -100,11 +101,11 @@ public struct StripeReaderRoutes: ReaderRoutes {
         return apiHandler.send(method: .POST, path: terminalreaders, body: .string(body.queryParameters), headers: headers)
     }
     
-    public func retrieve(reader: String) -> EventLoopFuture<StripeReader> {
+    public func retrieve(reader: String, context: LoggingContext) -> EventLoopFuture<StripeReader> {
         return apiHandler.send(method: .GET, path: "\(terminalreaders)/\(reader)", headers: headers)
     }
     
-    public func update(reader: String, label: String?, metadata: [String: String]?) -> EventLoopFuture<StripeReader> {
+    public func update(reader: String, label: String?, metadata: [String: String]?, context: LoggingContext) -> EventLoopFuture<StripeReader> {
         var body: [String: Any] = [:]
         
         if let label = label {
@@ -118,11 +119,11 @@ public struct StripeReaderRoutes: ReaderRoutes {
         return apiHandler.send(method: .POST, path: "\(terminalreaders)/\(reader)", body: .string(body.queryParameters), headers: headers)
     }
     
-    public func delete(reader: String) -> EventLoopFuture<StripeReader> {
+    public func delete(reader: String, context: LoggingContext) -> EventLoopFuture<StripeReader> {
         return apiHandler.send(method: .DELETE, path: "\(terminalreaders)/\(reader)", headers: headers)
     }
     
-    public func listAll(filter: [String: Any]?) -> EventLoopFuture<StripeReaderList> {
+    public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeReaderList> {
         var queryParams = ""
         if let filter = filter {
             queryParams = filter.queryParameters

--- a/Sources/StripeKit/Terminal/Reader/ReaderRoutes.swift
+++ b/Sources/StripeKit/Terminal/Reader/ReaderRoutes.swift
@@ -53,23 +53,23 @@ public protocol ReaderRoutes {
 
 extension ReaderRoutes {
     func create(registrationCode: String, label: String? = nil, location: String? = nil, metadata: [String: String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeReader> {
-        return create(registrationCode: registrationCode, label: label, location: location, metadata: metadata)
+        return create(registrationCode: registrationCode, label: label, location: location, metadata: metadata, context: context)
     }
     
     func retrieve(reader: String, context: LoggingContext) -> EventLoopFuture<StripeReader> {
-        return retrieve(reader: reader)
+        return retrieve(reader: reader, context: context)
     }
     
     func update(reader: String, label: String? = nil, metadata: [String: String]? = nil, context: LoggingContext) -> EventLoopFuture<StripeReader> {
-        return update(reader: reader, label: label, metadata: metadata)
+        return update(reader: reader, label: label, metadata: metadata, context: context)
     }
     
     func delete(reader: String, context: LoggingContext) -> EventLoopFuture<StripeReader> {
-        return delete(reader: reader)
+        return delete(reader: reader, context: context)
     }
     
     func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeReaderList> {
-        return listAll(filter: filter)
+        return listAll(filter: filter, context: context)
     }
 }
 
@@ -98,11 +98,11 @@ public struct StripeReaderRoutes: ReaderRoutes {
             metadata.forEach { body["metadata[\($0)]"] = $1 }
         }
         
-        return apiHandler.send(method: .POST, path: terminalreaders, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: terminalreaders, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(reader: String, context: LoggingContext) -> EventLoopFuture<StripeReader> {
-        return apiHandler.send(method: .GET, path: "\(terminalreaders)/\(reader)", headers: headers)
+        return apiHandler.send(method: .GET, path: "\(terminalreaders)/\(reader)", headers: headers, context: context)
     }
     
     public func update(reader: String, label: String?, metadata: [String: String]?, context: LoggingContext) -> EventLoopFuture<StripeReader> {
@@ -116,11 +116,11 @@ public struct StripeReaderRoutes: ReaderRoutes {
             metadata.forEach { body["metadata[\($0)]"] = $1 }
         }
         
-        return apiHandler.send(method: .POST, path: "\(terminalreaders)/\(reader)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(terminalreaders)/\(reader)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func delete(reader: String, context: LoggingContext) -> EventLoopFuture<StripeReader> {
-        return apiHandler.send(method: .DELETE, path: "\(terminalreaders)/\(reader)", headers: headers)
+        return apiHandler.send(method: .DELETE, path: "\(terminalreaders)/\(reader)", headers: headers, context: context)
     }
     
     public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeReaderList> {
@@ -129,6 +129,6 @@ public struct StripeReaderRoutes: ReaderRoutes {
             queryParams = filter.queryParameters
         }
         
-        return apiHandler.send(method: .GET, path: terminalreaders, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: terminalreaders, query: queryParams, headers: headers, context: context)
     }
 }

--- a/Sources/StripeKit/Webhooks/WebhookRoutes.swift
+++ b/Sources/StripeKit/Webhooks/WebhookRoutes.swift
@@ -59,11 +59,11 @@ extension WebhookEndpointRoutes {
                 apiVersion: String? = nil,
                 connect: Bool? = nil,
                 context: LoggingContext) -> EventLoopFuture<StripeWebhook> {
-        return create(enabledEvents: enabledEvents, url: url, metadata: metadata, apiVersion: apiVersion, connect: connect)
+        return create(enabledEvents: enabledEvents, url: url, metadata: metadata, apiVersion: apiVersion, connect: connect, context: context)
     }
     
     func retrieve(webhookEndpoint: String, context: LoggingContext) -> EventLoopFuture<StripeWebhook> {
-        return retrieve(webhookEndpoint: webhookEndpoint)
+        return retrieve(webhookEndpoint: webhookEndpoint, context: context)
     }
     
     func update(webhookEndpoint: String,
@@ -72,15 +72,15 @@ extension WebhookEndpointRoutes {
                 url: String? = nil,
                 metadata: [String: String]? = nil,
                 context: LoggingContext) -> EventLoopFuture<StripeWebhook> {
-        return update(webhookEndpoint: webhookEndpoint, disabled: disabled, enabledEvents: enabledEvents, url: url, metadata: metadata)
+        return update(webhookEndpoint: webhookEndpoint, disabled: disabled, enabledEvents: enabledEvents, url: url, metadata: metadata, context: context)
     }
     
     func listAll(filter: [String: Any]? = nil, context: LoggingContext) -> EventLoopFuture<StripeWebhookList> {
-        return listAll(filter: filter)
+        return listAll(filter: filter, context: context)
     }
     
     func delete(webhookEndpoint: String, context: LoggingContext) -> EventLoopFuture<StripeWebhook> {
-        return delete(webhookEndpoint: webhookEndpoint)
+        return delete(webhookEndpoint: webhookEndpoint, context: context)
     }
 }
 
@@ -110,11 +110,11 @@ public struct StripeWebhookEndpointRoutes: WebhookEndpointRoutes {
             body["connect"] = connect
         }
         
-        return apiHandler.send(method: .POST, path: webhooks, body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: webhooks, body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func retrieve(webhookEndpoint: String, context: LoggingContext) -> EventLoopFuture<StripeWebhook> {
-        return apiHandler.send(method: .GET, path: "\(webhooks)/\(webhookEndpoint)", headers: headers)
+        return apiHandler.send(method: .GET, path: "\(webhooks)/\(webhookEndpoint)", headers: headers, context: context)
     }
     
     public func update(webhookEndpoint: String,
@@ -141,7 +141,7 @@ public struct StripeWebhookEndpointRoutes: WebhookEndpointRoutes {
             metadata.forEach { body["metadata[\($0)]"] = $1 }
         }
         
-        return apiHandler.send(method: .POST, path: "\(webhooks)/\(webhookEndpoint)", body: .string(body.queryParameters), headers: headers)
+        return apiHandler.send(method: .POST, path: "\(webhooks)/\(webhookEndpoint)", body: .string(body.queryParameters), headers: headers, context: context)
     }
     
     public func listAll(filter: [String: Any]?, context: LoggingContext) -> EventLoopFuture<StripeWebhookList> {
@@ -149,11 +149,11 @@ public struct StripeWebhookEndpointRoutes: WebhookEndpointRoutes {
         if let filter = filter {
             queryParams = filter.queryParameters
         }
-        return apiHandler.send(method: .GET, path: webhooks, query: queryParams, headers: headers)
+        return apiHandler.send(method: .GET, path: webhooks, query: queryParams, headers: headers, context: context)
     }
     
     public func delete(webhookEndpoint: String, context: LoggingContext) -> EventLoopFuture<StripeWebhook> {
-        return apiHandler.send(method: .DELETE, path: "\(webhooks)/\(webhookEndpoint)", headers: headers)
+        return apiHandler.send(method: .DELETE, path: "\(webhooks)/\(webhookEndpoint)", headers: headers, context: context)
     }
 }
 


### PR DESCRIPTION
Draft PR for adding tracing to StripeKit. This is only a draft because you probably want to wait until task local values are available and using async/await.

This PR also makes it possible to change the API key easily without needing to create an entire new `StripeClient` which is quite expensive. Useful for SaaS providers running multi-tenant applications. Open to feedback on the implementation!