### PR TITLE
Make StripeSessionCustomerDetails.taxIds optional

### DIFF
--- a/Sources/StripeKit/Checkout/Sessions.swift
+++ b/Sources/StripeKit/Checkout/Sessions.swift
@@ -87,7 +87,7 @@ public struct StripeSessionCustomerDetails: StripeModel {
     /// The customer’s tax exempt status at time of checkout.
     public var taxExempt: String?
     /// The customer’s tax IDs at time of checkout.
-    public var taxIds: [StripeSessionCustomerDetailsTaxId]
+    public var taxIds: [StripeSessionCustomerDetailsTaxId]?
 }
 
 public struct StripeSessionCustomerDetailsTaxId: StripeModel {


### PR DESCRIPTION
The in some cases, especially in testing mode, the Stripe API does not return a key for the Tax ID, which causes parsing of the session to fail here. Making the `taxdIs` key optional fixes that.