### PR TITLE
ConnectAccount propery type changed from Date to Date?

### DIFF
--- a/Sources/StripeKit/Connect/Accounts/Account.swift
+++ b/Sources/StripeKit/Connect/Accounts/Account.swift
@@ -29,7 +29,7 @@ public struct StripeConnectAccount: StripeModel {
     /// The account’s country.
     public var country: String?
     /// Time at which the object was created. Measured in seconds since the Unix epoch.
-    public var created: Date
+    public var created: Date?
     /// Three-letter ISO currency code representing the default currency for the account. This must be a currency that Stripe supports in the account’s country.
     public var defaultCurrency: StripeCurrency?
     /// Whether account details have been submitted. Standard accounts cannot receive payouts before this is true.


### PR DESCRIPTION
This pull request fixes a bug where `stripe.connectAccounts.retrieve(account:)` fails to decode the Stripe API response.

As stated in [https://stripe.com/docs/api/accounts/object#account_object-created](https://stripe.com/docs/api/accounts/object#account_object-created), the `created` property exists only when the on boarding strategy is _express_ or _custom_, but it is never returned for _standard_.