### PR TITLE
Fix SwiftCrypto version requirement

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.1.0"),
-        .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0")
+        .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "3.0.0"),
     ],
     targets: [
         .target(name: "StripeKit", dependencies: [


### PR DESCRIPTION
This solves users of this package getting silently stuck on version 1.1.6 of swift-crypto (the current, source-compatible version is 2.0.3 as of this writing).

This fix requires an updated package release. Due to the updated dependency requirement, it should technically be `semver-minor`, though it almost certainly doesn't matter in practice if it's just `semver-patch` instead.