### PR TITLE
Add support for byn currency

### DIFF
--- a/Sources/StripeKit/Shared Models/Currency.swift
+++ b/Sources/StripeKit/Shared Models/Currency.swift
@@ -29,6 +29,7 @@ public enum StripeCurrency: String, StripeModel {
     case brl
     case bsd
     case bwp
+    case byn
     case bzd
     case cad
     case cdf


### PR DESCRIPTION
I am getting following error
▿ DecodingError
  ▿ dataCorrupted : Context
    ▿ codingPath : 2 elements
      - 0 : CodingKeys(stringValue: "supportedPaymentCurrencies", intValue: nil)
      ▿ 1 : _JSONKey(stringValue: "Index 22", intValue: 22)
        - stringValue : "Index 22"
        ▿ intValue : Optional<Int>
          - some : 22
    - debugDescription : "Cannot initialize StripeCurrency from invalid String value byn"
    - underlyingError : nil