### PR TITLE
Make refunds optional for webhooks

### DIFF
--- a/Sources/StripeKit/Core Resources/Charges/Charge.swift
+++ b/Sources/StripeKit/Core Resources/Charges/Charge.swift
@@ -81,7 +81,7 @@ public struct StripeCharge: StripeModel {
     /// Whether the charge has been fully refunded. If the charge is only partially refunded, this attribute will still be false.
     public var refunded: Bool?
     /// A list of refunds that have been applied to the charge.
-    public var refunds: StripeRefundsList
+    public var refunds: StripeRefundsList?
     /// ID of the review associated with this charge if one exists.
     @Expandable<StripeReview> public var review: String?
     /// Shipping information for the charge.


### PR DESCRIPTION
When using webhooks `refunds` should be an optional value 