### PR TITLE
make search request able to expand objects

### DIFF
--- a/Sources/StripeKit/Billing/Invoices/InvoiceRoutes.swift
+++ b/Sources/StripeKit/Billing/Invoices/InvoiceRoutes.swift
@@ -233,6 +233,15 @@ public protocol InvoiceRoutes: StripeAPIRoute {
     ///   - page: A cursor for pagination across multiple pages of results. Don’t include this parameter on the first call. Use the `next_page` value returned in a previous response to request subsequent results.
     /// - Returns: A dictionary with a `data` property that contains an array of up to `limit` invoices. If no objects match the query, the resulting array will be empty. See the related guide on expanding properties in lists.
     func search(query: String, limit: Int?, page: String?) async throws -> InvoiceSearchResult
+    
+    /// Search for invoices you’ve previously created using Stripe’s Search Query Language. Don’t use search in read-after-write flows where strict consistency is necessary. Under normal operating conditions, data is searchable in less than a minute. Occasionally, propagation of new or updated data can be up to an hour behind during outages. Search functionality is not available to merchants in India.
+    /// - Parameters:
+    ///   - query: The search query string. See search query language and the list of supported query fields for invoices.
+    ///   - limit: A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.
+    ///   - page: A cursor for pagination across multiple pages of results. Don’t include this parameter on the first call. Use the `next_page` value returned in a previous response to request subsequent results.
+    ///   - expand: Specifies which fields in the response should be expanded.
+    /// - Returns: A dictionary with a `data` property that contains an array of up to `limit` invoices. If no objects match the query, the resulting array will be empty. See the related guide on expanding properties in lists.
+    func search(query: String, limit: Int?, page: String?, expand:[String]?) async throws -> InvoiceSearchResult
 }
 
 public struct StripeInvoiceRoutes: InvoiceRoutes {
@@ -646,7 +655,21 @@ public struct StripeInvoiceRoutes: InvoiceRoutes {
     }
     
     public func search(query: String, limit: Int? = nil, page: String? = nil) async throws -> InvoiceSearchResult {
+        return try await search(query: query, limit: limit, page: page, expand: nil)
+    }
+    
+    public func search(query: String,
+                       limit: Int? = nil,
+                       page: String? = nil,
+                       expand:[String]? = nil) async throws -> InvoiceSearchResult {
         var queryParams: [String: Any] = ["query": query]
+        
+        var body: [String: Any] = [:]
+        
+        if let expand {
+            body["expand"] = expand
+        }
+        
         if let limit {
             queryParams["limit"] = limit
         }
@@ -655,6 +678,6 @@ public struct StripeInvoiceRoutes: InvoiceRoutes {
             queryParams["page"] = page
         }
         
-        return try await apiHandler.send(method: .GET, path: search, query: queryParams.queryParameters, headers: headers)
+        return try await apiHandler.send(method: .GET, path: search, query: queryParams.queryParameters, body: .string(body.queryParameters), headers: headers)
     }
 }

--- a/Sources/StripeKit/Billing/Subscriptions/SubscriptionRoutes.swift
+++ b/Sources/StripeKit/Billing/Subscriptions/SubscriptionRoutes.swift
@@ -218,6 +218,16 @@ public protocol SubscriptionRoutes: StripeAPIRoute {
     ///   - page: A cursor for pagination across multiple pages of results. Don’t include this parameter on the first call. Use the `next_page` value returned in a previous response to request subsequent results.
     /// - Returns: A dictionary with a `data` property that contains an array of up to `limit` subscriptions. If no objects match the query, the resulting array will be empty. See the related guide on expanding properties in lists.
     func search(query: String, limit: Int?, page: String?) async throws -> SubscriptionSearchResult
+    
+    /// Search for subscriptions you’ve previously created using Stripe’s Search Query Language. Don’t use search in read-after-write flows where strict consistency is necessary. Under normal operating conditions, data is searchable in less than a minute. Occasionally, propagation of new or updated data can be up to an hour behind during outages. Search functionality is not available to merchants in India.
+    /// - Parameters:
+    ///   - query: The search query string. See search query language and the list of supported query fields for invoices.
+    ///   - limit: A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.
+    ///   - page: A cursor for pagination across multiple pages of results. Don’t include this parameter on the first call. Use the `next_page` value returned in a previous response to request subsequent results.
+    ///   - expand: Specifies which fields in the response should be expanded.
+    /// - Returns: A dictionary with a `data` property that contains an array of up to `limit` subscriptions. If no objects match the query, the resulting array will be empty. See the related guide on expanding properties in lists.
+    func search(query: String, limit: Int?, page: String?, expand:[String]?) async throws -> SubscriptionSearchResult
+
 }
 
 public struct StripeSubscriptionRoutes: SubscriptionRoutes {
@@ -614,7 +624,21 @@ public struct StripeSubscriptionRoutes: SubscriptionRoutes {
     }
     
     public func search(query: String, limit: Int? = nil, page: String? = nil) async throws -> SubscriptionSearchResult {
+        return try await self.search(query: query, limit:limit, page:page, expand:nil)
+    }
+    
+    public func search(query: String,
+                       limit: Int? = nil,
+                       page: String? = nil,
+                       expand:[String]? = nil) async throws -> SubscriptionSearchResult {
         var queryParams: [String: Any] = ["query": query]
+        
+        var body: [String: Any] = [:]
+        
+        if let expand {
+            body["expand"] = expand
+        }
+        
         if let limit {
             queryParams["limit"] = limit
         }
@@ -623,6 +647,6 @@ public struct StripeSubscriptionRoutes: SubscriptionRoutes {
             queryParams["page"] = page
         }
         
-        return try await apiHandler.send(method: .GET, path: search, query: queryParams.queryParameters, headers: headers)
+        return try await apiHandler.send(method: .GET, path: search, query: queryParams.queryParameters, body: .string(body.queryParameters), headers: headers)
     }
 }

--- a/Sources/StripeKit/Core Resources/Customers/CustomerRoutes.swift
+++ b/Sources/StripeKit/Core Resources/Customers/CustomerRoutes.swift
@@ -135,6 +135,7 @@ public protocol CustomerRoutes: StripeAPIRoute {
     ///   - expand: Specifies which fields in the response should be expanded.
     /// - Returns: A dictionary with a data property that contains an array of up to limit customers. If no objects match the query, the resulting array will be empty. See the related guide on expanding properties in lists.
     func search(query: String, limit: Int?, page: String?, expand: [String]?) async throws -> CustomerSearchResult
+
 }
 
 public struct StripeCustomerRoutes: CustomerRoutes {
@@ -412,7 +413,14 @@ public struct StripeCustomerRoutes: CustomerRoutes {
         if let page {
             queryParams["page"] = page
         }
+        var body: [String: Any] = [:]
         
-        return try await apiHandler.send(method: .GET, path: search, query: queryParams.queryParameters, headers: headers)
+        if let expand {
+            body["expand"] = expand
+        }
+        
+        return try await apiHandler.send(method: .GET, path: search, query: queryParams.queryParameters, body: .string(body.queryParameters), headers: headers)
+
     }
+    
 }

--- a/Sources/StripeKit/Core Resources/PaymentIntents/PaymentIntentRoutes.swift
+++ b/Sources/StripeKit/Core Resources/PaymentIntents/PaymentIntentRoutes.swift
@@ -240,8 +240,18 @@ public protocol PaymentIntentRoutes: StripeAPIRoute {
     ///   - query: The search query string. See search query language and the list of supported query fields for payment intents.
     ///   - limit: A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.
     ///   - page: A cursor for pagination across multiple pages of results. Don’t include this parameter on the first call. Use the `next_page` value returned in a previous response to request subsequent results.
+    ///   - expand: Specifies which fields in the response should be expanded.
     /// - Returns: A dictionary with a data property that contains an array of up to limit PaymentIntents. If no objects match the query, the resulting array will be empty. See the related guide on expanding properties in lists.
     func search(query: String, limit: Int?, page: String?) async throws -> PaymentIntentSearchResult
+    
+    /// Search for PaymentIntents you’ve previously created using Stripe’s Search Query Language. Don’t use search in read-after-write flows where strict consistency is necessary. Under normal operating conditions, data is searchable in less than a minute. Occasionally, propagation of new or updated data can be up to an hour behind during outages. Search functionality is not available to merchants in India.
+    /// - Parameters:
+    ///   - query: The search query string. See search query language and the list of supported query fields for payment intents.
+    ///   - limit: A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.
+    ///   - page: A cursor for pagination across multiple pages of results. Don’t include this parameter on the first call. Use the `next_page` value returned in a previous response to request subsequent results.
+    /// - Returns: A dictionary with a data property that contains an array of up to limit PaymentIntents. If no objects match the query, the resulting array will be empty. See the related guide on expanding properties in lists.
+    func search(query: String, limit: Int?, page: String?, expand:[String]?) async throws -> PaymentIntentSearchResult
+    
     
     /// Verifies microdeposits on a PaymentIntent object.
     /// - Parameters:
@@ -708,7 +718,21 @@ public struct StripePaymentIntentRoutes: PaymentIntentRoutes {
     public func search(query: String,
                        limit: Int? = nil,
                        page: String? = nil) async throws -> PaymentIntentSearchResult {
+        return try await self.search(query: query, limit:limit, page:page, expand:nil)
+    }
+    
+    public func search(query: String,
+                       limit: Int? = nil,
+                       page: String? = nil,
+                       expand:[String]? = nil) async throws -> PaymentIntentSearchResult {
         var queryParams: [String: Any] = ["query": query]
+        
+        var body: [String: Any] = [:]
+        
+        if let expand {
+            body["expand"] = expand
+        }
+        
         if let limit {
             queryParams["limit"] = limit
         }
@@ -717,7 +741,7 @@ public struct StripePaymentIntentRoutes: PaymentIntentRoutes {
             queryParams["page"] = page
         }
         
-        return try await apiHandler.send(method: .GET, path: "\(paymentintents)/search", query: queryParams.queryParameters, headers: headers)
+        return try await apiHandler.send(method: .GET, path: "\(paymentintents)/search", query: queryParams.queryParameters, body: .string(body.queryParameters), headers: headers)
     }
     
     public func verifyMicroDeposits(intent: String,

--- a/Sources/StripeKit/Products/Prices/PriceRoutes.swift
+++ b/Sources/StripeKit/Products/Prices/PriceRoutes.swift
@@ -87,6 +87,16 @@ public protocol PriceRoutes: StripeAPIRoute {
     ///   - page: A cursor for pagination across multiple pages of results. Don’t include this parameter on the first call. Use the `next_page` value returned in a previous response to request subsequent results.
     /// - Returns: A dictionary with a `data` property that contains an array of up to `limit` prices. If no objects match the query, the resulting array will be empty. See the related guide on expanding properties in lists.
     func search(query: String, limit: Int?, page: String?) async throws -> PriceSearchResult
+    
+    
+    /// Search for prices you’ve previously created using Stripe’s Search Query Language. Don’t use search in read-after-write flows where strict consistency is necessary. Under normal operating conditions, data is searchable in less than a minute. Occasionally, propagation of new or updated data can be up to an hour behind during outages. Search functionality is not available to merchants in India.
+    /// - Parameters:
+    ///   - query: The search query string. See search query language and the list of supported query fields for prices.
+    ///   - limit: A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.
+    ///   - page: A cursor for pagination across multiple pages of results. Don’t include this parameter on the first call. Use the `next_page` value returned in a previous response to request subsequent results.
+    ///   - expand: Specifies which fields in the response should be expanded.
+    /// - Returns: A dictionary with a `data` property that contains an array of up to `limit` prices. If no objects match the query, the resulting array will be empty. See the related guide on expanding properties in lists.
+    func search(query: String, limit: Int?, page: String?, expand:[String]?) async throws -> PriceSearchResult
 }
 
 public struct StripePriceRoutes: PriceRoutes {
@@ -268,7 +278,21 @@ public struct StripePriceRoutes: PriceRoutes {
     public func search(query: String,
                        limit: Int? = nil,
                        page: String? = nil) async throws -> PriceSearchResult {
+        return try await self.search(query: query, limit: limit, page:page, expand:nil)
+    }
+    
+    public func search(query: String,
+                       limit: Int? = nil,
+                       page: String? = nil,
+                       expand:[String]? = nil) async throws -> PriceSearchResult {
         var queryParams: [String: Any] = ["query": query]
+        
+        var body: [String: Any] = [:]
+        
+        if let expand {
+            body["expand"] = expand
+        }
+        
         if let limit {
             queryParams["limit"] = limit
         }
@@ -277,6 +301,6 @@ public struct StripePriceRoutes: PriceRoutes {
             queryParams["page"] = page
         }
         
-        return try await apiHandler.send(method: .GET, path: search, query: queryParams.queryParameters, headers: headers)
+        return try await apiHandler.send(method: .GET, path: search, query: queryParams.queryParameters, body: .string(body.queryParameters), headers: headers)
     }
 }

--- a/Sources/StripeKit/Products/Products/ProductRoutes.swift
+++ b/Sources/StripeKit/Products/Products/ProductRoutes.swift
@@ -98,6 +98,16 @@ public protocol ProductRoutes: StripeAPIRoute {
     ///   - page: A cursor for pagination across multiple pages of results. Don’t include this parameter on the first call. Use the `next_page` value returned in a previous response to request subsequent results.
     /// - Returns: A dictionary with a `data` property that contains an array of up to `limit` products. If no objects match the query, the resulting array will be empty. See the related guide on expanding properties in lists.
     func search(query: String, limit: Int?, page: String?) async throws -> ProductSearchResult
+    
+    
+    /// Search for products you’ve previously created using Stripe’s Search Query Language. Don’t use search in read-after-write flows where strict consistency is necessary. Under normal operating conditions, data is searchable in less than a minute. Occasionally, propagation of new or updated data can be up to an hour behind during outages. Search functionality is not available to merchants in India.
+    /// - Parameters:
+    ///   - query: The search query string. See search query language and the list of supported query fields for products.
+    ///   - limit: A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.
+    ///   - page: A cursor for pagination across multiple pages of results. Don’t include this parameter on the first call. Use the `next_page` value returned in a previous response to request subsequent results.
+    ///   - expand: Specifies which fields in the response should be expanded.
+    /// - Returns: A dictionary with a `data` property that contains an array of up to `limit` products. If no objects match the query, the resulting array will be empty. See the related guide on expanding properties in lists.
+    func search(query: String, limit: Int?, page: String?, expand:[String]?) async throws -> ProductSearchResult
 }
 
 public struct StripeProductRoutes: ProductRoutes {
@@ -265,7 +275,21 @@ public struct StripeProductRoutes: ProductRoutes {
     public func search(query: String,
                        limit: Int? = nil,
                        page: String? = nil) async throws -> ProductSearchResult {
+        return try await self.search(query: query, limit:limit, page: page, expand:nil)
+    }
+    
+    public func search(query: String,
+                       limit: Int? = nil,
+                       page: String? = nil,
+                       expand:[String]? = nil) async throws -> ProductSearchResult {
         var queryParams: [String: Any] = ["query": query]
+        
+        var body: [String: Any] = [:]
+        
+        if let expand {
+            body["expand"] = expand
+        }
+        
         if let limit {
             queryParams["limit"] = limit
         }


### PR DESCRIPTION
I changed all search routes to add "expand" parameter in the request body. 
I needed it for my project, so I wanted to share it.