### PR TITLE
Fix PaymentIntent cancelation

### DIFF
--- a/Sources/StripeKit/Core Resources/PaymentIntents/PaymentIntent.swift
+++ b/Sources/StripeKit/Core Resources/PaymentIntents/PaymentIntent.swift
@@ -226,10 +226,13 @@ public struct PaymentIntentTransferData: Codable {
 }
 
 public enum PaymentIntentCancellationReason: String, Codable {
+    case abandoned
+    case automatic
     case duplicate
+    case failedInvoice = "failed_invoice"
     case fraudulent
     case requestedByCustomer = "requested_by_customer"
-	case abandoned
+    case voidInvoice = "void_invoice"
 }
 
 public enum PaymentIntentCaptureMethod: String, Codable {

--- a/Sources/StripeKit/Core Resources/PaymentIntents/PaymentIntent.swift
+++ b/Sources/StripeKit/Core Resources/PaymentIntents/PaymentIntent.swift
@@ -229,10 +229,7 @@ public enum PaymentIntentCancellationReason: String, Codable {
     case duplicate
     case fraudulent
     case requestedByCustomer = "requested_by_customer"
-    case failedInvoice = "failed_invoice"
-    case voidInvoice = "void_invoice"
 	case abandoned
-    case automatic
 }
 
 public enum PaymentIntentCaptureMethod: String, Codable {

--- a/Sources/StripeKit/Core Resources/PaymentIntents/PaymentIntent.swift
+++ b/Sources/StripeKit/Core Resources/PaymentIntents/PaymentIntent.swift
@@ -231,6 +231,7 @@ public enum PaymentIntentCancellationReason: String, Codable {
     case requestedByCustomer = "requested_by_customer"
     case failedInvoice = "failed_invoice"
     case voidInvoice = "void_invoice"
+	case abandoned
     case automatic
 }
 


### PR DESCRIPTION
### Description

While using this library I noticed canceling a payment intent was not possible. More specifically was the cancellation_reason not supported. After checking the docs I've updated the enum and can confirm it works now.

### Tasks

- [x] update PaymentIntentCancellationReason enum

### Infos for Reviewer

I'm using the Payment Intent in combination with Stripe Connect. I couldn't verify if the behavior is different with another stripe product, however it says the same in the documentation here: https://stripe.com/docs/api/payment_intents/cancel

Here is the error returned from the API:
```
The cancellation_reason provided in the request is not a valid user provided reason. 
Please try canceling again with one of duplicate`, `fraudulent`, `requested_by_customer`
or `abandoned.

{
  "cancellation_reason": "automatic"
}
```
