### PR TITLE
Missing capture method: Update PaymentIntent.swift

### DIFF
--- a/Sources/StripeKit/Core Resources/PaymentIntents/PaymentIntent.swift
+++ b/Sources/StripeKit/Core Resources/PaymentIntents/PaymentIntent.swift
@@ -238,6 +238,7 @@ public enum PaymentIntentCancellationReason: String, Codable {
 public enum PaymentIntentCaptureMethod: String, Codable {
     /// (Default) Stripe automatically captures funds when the customer authorizes the payment.
     case automatic
+    case automaticAsync = "automatic_async"
     /// Place a hold on the funds when the customer authorizes the payment, but don’t capture the funds until later. (Not all payment methods support this.)
     case manual
 }


### PR DESCRIPTION
Stripe has new enum for 'PaymentIntentCaptureMethod'

Example stripe webhook data:

![Screenshot 2024-05-13 at 11 42 22](https://github.com/vapor-community/stripe-kit/assets/36151747/17185090-0514-47e8-8502-dc6ef896c01e)
