### PR TITLE
Extend swift-crypto allowed version range

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.1.0"),
-        .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "3.0.0"),
+        .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "4.0.0"),
     ],
     targets: [
         .target(name: "StripeKit", dependencies: [


### PR DESCRIPTION
As per https://github.com/apple/swift-crypto/releases/tag/3.0.0 the version 3.0 should be allowed in the range for `swift-crypto`. Not allowing this version makes using `stripe-kit` incompatible with `jwt-kit` 5 beta.

This reopens #249 which I closed by mistake (my bad 😞).