### PR TITLE
Make Currency CaseIterable

### DIFF
--- a/Sources/StripeKit/Shared Models/Currency.swift
+++ b/Sources/StripeKit/Shared Models/Currency.swift
@@ -6,7 +6,7 @@
 //
 //
 
-public enum Currency: String, Codable {
+public enum Currency: String, Codable, CaseIterable {
     case usd
     case aed
     case afn


### PR DESCRIPTION
This is useful to retrieve the list of the supported currencies by Stripe.