### PR TITLE
add expand to product endpoints

### DIFF
--- a/Sources/StripeKit/Products/Products/ProductRoutes.swift
+++ b/Sources/StripeKit/Products/Products/ProductRoutes.swift
@@ -40,13 +40,14 @@ public protocol ProductRoutes: StripeAPIRoute {
                 statementDescriptor: String?,
                 taxCode: String?,
                 unitLabel: String?,
-                url: String?) async throws -> Product
+                url: String?,
+                expand: [String]?) async throws -> Product
     
     /// Retrieves the details of an existing product. Supply the unique product ID from either a product creation request or the product list, and Stripe will return the corresponding product information.
     ///
     /// - Parameter id: The identifier of the product to be retrieved.
     /// - Returns: Returns a product object if a valid identifier was provided.
-    func retrieve(id: String) async throws -> Product
+    func retrieve(id: String, expand: [String]?) async throws -> Product
     
     /// Updates the specific product by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
     /// - Parameters:
@@ -77,7 +78,8 @@ public protocol ProductRoutes: StripeAPIRoute {
                 statementDescriptor: String?,
                 taxCode: String?,
                 unitLabel: String?,
-                url: String?) async throws -> Product
+                url: String?,
+                expand: [String]?) async throws -> Product
     
     /// Returns a list of your products. The products are returned sorted by creation date, with the most recently created products appearing first.
     ///
@@ -123,7 +125,8 @@ public struct StripeProductRoutes: ProductRoutes {
                        statementDescriptor: String? = nil,
                        taxCode: String? = nil,
                        unitLabel: String? = nil,
-                       url: String? = nil) async throws -> Product {
+                       url: String? = nil,
+                       expand: [String]? = nil) async throws -> Product {
         var body: [String: Any] = [:]
         
         body["name"] = name
@@ -175,12 +178,20 @@ public struct StripeProductRoutes: ProductRoutes {
         if let url {
             body["url"] = url
         }
+
+        if let expand {
+            body["expand"] = expand
+        }
         
         return try await apiHandler.send(method: .POST, path: products, body: .string(body.queryParameters), headers: headers)
     }
     
-    public func retrieve(id: String) async throws -> Product {
-        try await apiHandler.send(method: .GET, path: "\(products)/\(id)", headers: headers)
+    public func retrieve(id: String, expand: [String]? = nil) async throws -> Product {
+        var queryParams = ""
+        if let expand {
+            queryParams = ["expand": expand].queryParameters
+        }
+        return try await apiHandler.send(method: .GET, path: "\(products)/\(id)", query: queryParams, headers: headers)
     }
     
     public func update(product: String,
@@ -195,7 +206,8 @@ public struct StripeProductRoutes: ProductRoutes {
                        statementDescriptor: String? = nil,
                        taxCode: String? = nil,
                        unitLabel: String? = nil,
-                       url: String? = nil) async throws -> Product {
+                       url: String? = nil,
+                       expand: [String]? = nil) async throws -> Product {
         var body: [String: Any] = [:]
         
         if let active {
@@ -244,6 +256,10 @@ public struct StripeProductRoutes: ProductRoutes {
         
         if let url {
             body["url"] = url
+        }
+
+        if let expand {
+            body["expand"] = expand
         }
         
         return try await apiHandler.send(method: .POST, path: "\(products)/\(product)", body: .string(body.queryParameters), headers: headers)


### PR DESCRIPTION
This adds expand to products in the same way its being used throughout the rest of the library.

While it would be nice to be able to do this without a breaking change, I think it's more important to keep things consistent in the approach. This means that anyone using these product endpoints will have to update their code to pass `nil` for expand.

Let me know if anything additional is needed here.