### PR TITLE
feat: Issuer Identification Number

### DIFF
--- a/Sources/StripeKit/Payment Methods/PaymentMethods/PaymentMethods.swift
+++ b/Sources/StripeKit/Payment Methods/PaymentMethods/PaymentMethods.swift
@@ -133,6 +133,8 @@ public struct PaymentMethodCard: Codable {
     public var threeDSecureUsage: PaymentMethodCardThreeDSecureUsage?
     /// If this Card is part of a card wallet, this contains the details of the card wallet.
     public var wallet: PaymentMethodCardWallet?
+    /// The issuer identification number for the card. This is the first six digits of a card number.
+    public var iin: String?
     
     public init(brand: PaymentMethodDetailsCardBrand? = nil,
                 checks: PaymentMethodDetailsCardChecks? = nil,
@@ -145,7 +147,8 @@ public struct PaymentMethodCard: Codable {
                 last4: String? = nil,
                 networks: PaymentMethodCardNetworks? = nil,
                 threeDSecureUsage: PaymentMethodCardThreeDSecureUsage? = nil,
-                wallet: PaymentMethodCardWallet? = nil) {
+                wallet: PaymentMethodCardWallet? = nil,
+                iin: String? = nil) {
         self.brand = brand
         self.checks = checks
         self.country = country
@@ -158,6 +161,7 @@ public struct PaymentMethodCard: Codable {
         self.networks = networks
         self.threeDSecureUsage = threeDSecureUsage
         self.wallet = wallet
+        self.iin = iin
     }
 }
 


### PR DESCRIPTION
This fix the issue https://github.com/vapor-community/stripe-kit/issues/265 adding a new field IIN on `PaymentMethodCard` object so that it can represents a Issuer Identification Number.