### PR TITLE
Fix typo EventObject.earlyFraudWarniing to EventObject.earlyFraudWarning

### DIFF
--- a/Sources/StripeKit/Core Resources/Events/Event.swift
+++ b/Sources/StripeKit/Core Resources/Events/Event.swift
@@ -104,7 +104,7 @@ public enum EventObject: Codable {
     case price(Price)
     case product(Product)
     case promotionCode(PromotionCode)
-    case earlyFraudWarniing(EarlyFraudWarning)
+    case earlyFraudWarning(EarlyFraudWarning)
     case quote(Quote)
     case reportRun(ReportRun)
     case reportType(ReportType)
@@ -203,7 +203,7 @@ public enum EventObject: Codable {
         case "promotion_code":
             self = try .promotionCode(PromotionCode(from: decoder))
         case "radar.early_fraud_warning":
-            self = try .earlyFraudWarniing(EarlyFraudWarning(from: decoder))
+            self = try .earlyFraudWarning(EarlyFraudWarning(from: decoder))
         case "quote":
             self = try .quote(Quote(from: decoder))
         case "reporting.report_run":
@@ -313,7 +313,7 @@ public enum EventObject: Codable {
             try product.encode(to: encoder)
         case .promotionCode(let promotionCode):
             try promotionCode.encode(to: encoder)
-        case .earlyFraudWarniing(let earlyFraudWarning):
+        case .earlyFraudWarning(let earlyFraudWarning):
             try earlyFraudWarning.encode(to: encoder)
         case .quote(let quote):
             try quote.encode(to: encoder)


### PR DESCRIPTION
Warning is spelled with one 'i'.