### PR TITLE
fix: Swift 6.3: Explicit dependency on swift-nio for NIOFoundationCompat

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,12 +14,14 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.1.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.81.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "5.0.0"),
     ],
     targets: [
         .target(name: "StripeKit", dependencies: [
             .product(name: "AsyncHTTPClient", package: "async-http-client"),
             .product(name: "Crypto", package: "swift-crypto"),
+            .product(name: "NIOFoundationCompat", package: "swift-nio")
         ]),
         .testTarget(name: "StripeKitTests", dependencies: [
             .target(name: "StripeKit")

--- a/Package.swift
+++ b/Package.swift
@@ -13,9 +13,9 @@ let package = Package(
         .library(name: "StripeKit", targets: ["StripeKit"])
     ],
     dependencies: [
-        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.1.0"),
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.81.0"),
-        .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "5.0.0"),
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.33.1"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.97.1"),
+        .package(url: "https://github.com/apple/swift-crypto.git", "3.0.0" ..< "5.0.0"),
     ],
     targets: [
         .target(name: "StripeKit", dependencies: [


### PR DESCRIPTION
This PR is an attempt to fix what (seems to be) a recent break I see when building on Linux under Swift 6.3.

`stripe-kit` imports `NIOFoundationCompat` in its code but doesn't declare a dependency on it in Package.swift.

Looking upstream, the `AsyncHTTPClient` target in `async-http-client` comprehensively depends on the other products of `swift-nio` but it doesn't depend on `NIOFoundationCompat` (only the `AsyncHTTPClientTests` target does):
https://github.com/swift-server/async-http-client/blob/main/Package.swift

Somehow previously this worked, but in Swift 6.3 the behaviour of SPM seems have changed.

From my testing, I expect the api-breakage test on this PR to fail, but I'm unsure if this is a legitimate failure, sorry.