### PR TITLE
Add revolut_pay to PaymentMethodType

### DIFF
--- a/Sources/StripeKit/Payment Methods/PaymentMethods/PaymentMethod.swift
+++ b/Sources/StripeKit/Payment Methods/PaymentMethods/PaymentMethod.swift
@@ -193,6 +193,7 @@ public enum PaymentMethodType: String, Codable {
     case paynow
     case pix
     case promptpay
+    case revolutPay = "revolut_pay"
     case sepaDebit = "sepa_debit"
     case sofort
     case usBankAccount = "us_bank_account"


### PR DESCRIPTION
Add a new PaymentMethodType enum case for Revolut Pay mapped to the API value "revolut_pay". This enables handling of the Revolut Pay payment method in PaymentMethod decoding/encoding (Sources/StripeKit/Payment Methods/PaymentMethods/PaymentMethod.swift).